### PR TITLE
chore: update version to 1.0.1 and add publish workflow for npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'npm'
+          always-auth: true
+
+      - name: Configure npm auth
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: |
+          npm run typecheck
+          npm run lint
+          npm run format:check
+          npm run test:run
+          npm run build
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-design-system-extractor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simplified MCP server for Storybook design system extraction with component analysis tools",
   "author": "graslt",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces automated publishing to npm and increments the package version. The main change is the addition of a GitHub Actions workflow to handle publishing upon new releases or tags, ensuring a streamlined and secure release process.

Automation and release process:

* Added a new GitHub Actions workflow in `.github/workflows/publish.yml` to automate publishing to npm on release, tag push, or manual dispatch. The workflow includes steps for dependency installation, code checks (typecheck, lint, format, test, build), and publishing with provenance and authentication.

Version management:

* Updated the package version in `package.json` from `1.0.0` to `1.0.1` to reflect the new release.