### PR TITLE
feat: Add Claude Code plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-design-system-extractor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Simplified MCP server for Storybook design system extraction with component analysis tools",
   "author": "graslt",
   "license": "MIT",

--- a/plugins/claude/design-system/.claude-plugin/plugin.json
+++ b/plugins/claude/design-system/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "design-system",
+  "description": "Extract components from Storybook design systems. Get HTML, styles, themes, and component metadata for AI-assisted UI development.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Tomáš Grasl",
+    "url": "https://www.tomasgrasl.cz/"
+  },
+  "repository": "https://github.com/freema/mcp-design-system-extractor",
+  "license": "MIT"
+}

--- a/plugins/claude/design-system/.claude-plugin/plugin.json
+++ b/plugins/claude/design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-system",
   "description": "Extract components from Storybook design systems. Get HTML, styles, themes, and component metadata for AI-assisted UI development.",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "author": {
     "name": "Tomáš Grasl",
     "url": "https://www.tomasgrasl.cz/"

--- a/plugins/claude/design-system/.mcp.json
+++ b/plugins/claude/design-system/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "design-system": {
+      "command": "npx",
+      "args": ["-y", "mcp-design-system-extractor@latest"]
+    }
+  }
+}

--- a/plugins/claude/design-system/README.md
+++ b/plugins/claude/design-system/README.md
@@ -1,0 +1,72 @@
+# Design System Extractor Plugin for Claude Code
+
+Extract components, HTML, styles, and themes from Storybook design systems for AI-assisted UI development.
+
+## What's Included
+
+- **MCP Server** - Connects Claude Code to Storybook instances
+- **Skills** - Auto-triggers when building UIs with design systems
+- **Agents** - `ui-builder` for component-based development
+- **Commands** - `/design:list`, `/design:extract`, `/design:theme`
+
+## Installation
+
+```bash
+claude plugin install design-system
+```
+
+**Required environment variable:**
+```
+STORYBOOK_URL=http://localhost:6006
+```
+
+## Commands
+
+### /design:list
+
+List all components in the design system:
+
+```
+/design:list
+/design:list buttons
+/design:list --category=forms
+```
+
+### /design:extract
+
+Extract HTML from a component:
+
+```
+/design:extract button--primary
+/design:extract card--default
+```
+
+### /design:theme
+
+Get design system theme (colors, spacing, typography):
+
+```
+/design:theme
+/design:theme colors
+```
+
+## Agents
+
+Spawn the UI builder for focused development:
+
+```
+spawn ui-builder to create a login form using the design system
+spawn ui-builder to build a dashboard layout with cards
+```
+
+## Usage Examples
+
+- "Show me all button variants"
+- "Extract the HTML for the primary button"
+- "What colors are in the design system?"
+- "Build a form using the design system components"
+
+## Links
+
+- [Repository](https://github.com/freema/mcp-design-system-extractor)
+- [npm](https://www.npmjs.com/package/mcp-design-system-extractor)

--- a/plugins/claude/design-system/agents/ui-builder.md
+++ b/plugins/claude/design-system/agents/ui-builder.md
@@ -1,0 +1,39 @@
+---
+name: ui-builder
+description: Agent for building UIs using Storybook design system components. Extracts components and assembles them into complete interfaces.
+model: sonnet
+---
+
+You are a UI builder agent specializing in component-based development using Storybook design systems.
+
+## Your Task
+
+When given a UI task, find appropriate components from the design system, extract their HTML/styles, and assemble them into the requested interface.
+
+## Process
+
+1. **Understand requirements**: What UI needs to be built?
+2. **Search components**: Use `search_components` to find relevant components
+3. **Check variants**: Use `get_component_html` with `variantsOnly: true`
+4. **Extract HTML**: Get the actual HTML for chosen variants
+5. **Get theme**: Use `get_theme_info` for colors, spacing if needed
+6. **Assemble**: Combine components into the final UI
+7. **Return**: Provide clean, usable code
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `list_components` | List all components (use `compact: true`) |
+| `search_components` | Find components by name/purpose |
+| `get_component_html` | Extract HTML (async, poll with `job_status`) |
+| `get_theme_info` | Get design tokens |
+| `get_component_dependencies` | See component relationships |
+
+## Guidelines
+
+- Always use `compact: true` when listing components
+- Check variants before extracting HTML
+- Use design system colors/spacing from theme
+- Return clean, production-ready code
+- Mention which components were used

--- a/plugins/claude/design-system/commands/extract.md
+++ b/plugins/claude/design-system/commands/extract.md
@@ -1,0 +1,32 @@
+---
+description: Extract HTML from a Storybook component
+argument-hint: <component-id>
+---
+
+# /design:extract
+
+Extract the rendered HTML from a specific component story.
+
+## Usage
+
+```
+/design:extract <component-id>
+```
+
+Component ID format: `component-name--story-name` or just `component-name` (uses default variant).
+
+## Examples
+
+```
+/design:extract button--primary
+/design:extract card--default
+/design:extract input
+```
+
+## What Happens
+
+1. Calls `get_component_html` in async mode (returns job_id)
+2. Polls `job_status` until complete
+3. Returns the extracted HTML
+
+Use `variantsOnly: true` to first see available variants.

--- a/plugins/claude/design-system/commands/list.md
+++ b/plugins/claude/design-system/commands/list.md
@@ -1,0 +1,29 @@
+---
+description: List components in the Storybook design system
+argument-hint: [search-query]
+---
+
+# /design:list
+
+List all components available in the Storybook design system.
+
+## Usage
+
+```
+/design:list                    # All components
+/design:list <query>            # Search by name
+/design:list --category=<cat>   # Filter by category
+```
+
+## Examples
+
+```
+/design:list
+/design:list button
+/design:list --category=forms
+/design:list input
+```
+
+## What Happens
+
+Calls `list_components` with `compact: true` for minimal output, or `search_components` if a query is provided.

--- a/plugins/claude/design-system/commands/theme.md
+++ b/plugins/claude/design-system/commands/theme.md
@@ -1,0 +1,28 @@
+---
+description: Get design system theme (colors, spacing, typography)
+argument-hint: [section]
+---
+
+# /design:theme
+
+Extract design tokens and theme information from the design system.
+
+## Usage
+
+```
+/design:theme                # Full theme
+/design:theme <section>      # Specific section
+```
+
+## Examples
+
+```
+/design:theme
+/design:theme colors
+/design:theme spacing
+/design:theme typography
+```
+
+## What Happens
+
+Calls `get_theme_info` to extract CSS custom properties and design tokens including colors, spacing, typography, and breakpoints.

--- a/plugins/claude/design-system/skills/design-extraction/SKILL.md
+++ b/plugins/claude/design-system/skills/design-extraction/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: design-extraction
+description: This skill should be used when the user asks about Storybook, design systems, UI components, extracting HTML, or building interfaces using existing components. Activates for component listing, HTML extraction, theme analysis, or UI assembly.
+---
+
+When the user asks about design systems or building UIs with components, use the design-system MCP tools.
+
+## When to Use This Skill
+
+Activate when the user:
+
+- Asks about available components ("What buttons do we have?", "List form components")
+- Needs component HTML ("Extract the card component", "Get the modal HTML")
+- Wants theme info ("What colors are available?", "Show me the spacing scale")
+- Builds UIs ("Create a login form using our components")
+- Analyzes components ("What components does the header use?")
+
+## Tools Reference
+
+| Task | Tool |
+|------|------|
+| List all | `list_components` (use `compact: true`) |
+| Search | `search_components` |
+| Extract HTML | `get_component_html` (async) |
+| Check variants | `get_component_html` with `variantsOnly: true` |
+| Get theme | `get_theme_info` |
+| Get CSS | `get_external_css` |
+| Dependencies | `get_component_dependencies` |
+| Job status | `job_status` |
+
+## Async Operations
+
+`get_component_html` is async by default:
+
+```
+get_component_html componentId="button--primary"
+→ Returns: { job_id: "abc123" }
+
+job_status jobId="abc123"
+→ Returns: { status: "completed", result: "<button>..." }
+```
+
+## Component ID Format
+
+```
+button--primary     # component--story
+card--default       # component--story
+button              # auto-resolves to default variant
+```
+
+## Example Workflows
+
+**List and extract:**
+```
+list_components compact=true
+get_component_html componentId="button" variantsOnly=true
+get_component_html componentId="button--primary"
+job_status jobId="..."
+```
+
+**Build with theme:**
+```
+get_theme_info
+search_components purpose="form inputs"
+get_component_html componentId="input--default"
+```


### PR DESCRIPTION
Adds Claude Code plugin with:

- **Commands**: `/design:list`, `/design:extract`, `/design:theme`
- **Agents**: `ui-builder`
- **Skills**: `design-extraction` (auto-triggers for design system tasks)

Structure follows context7 plugin pattern.