### PR TITLE
test: cover the tools, job queue and Storybook client

### DIFF
--- a/src/tools/get-theme-info.ts
+++ b/src/tools/get-theme-info.ts
@@ -109,12 +109,17 @@ export async function handleGetThemeInfo(input: any) {
     for (const [name, value] of Object.entries(allTokens)) {
       const lowerName = name.toLowerCase();
 
+      // What the token is called beats what its value looks like. The value
+      // heuristics used to run inside the colour and spacing branches, so
+      // every bare unit value was swallowed as spacing: `--breakpoint-md:
+      // 960px` and `--radius-sm: 2px` never reached their own bucket, and the
+      // empty-breakpoints fallback below then filled the response with
+      // defaults the design system had actually defined.
       if (
         lowerName.includes('color') ||
         lowerName.includes('bg') ||
         lowerName.includes('text') ||
-        lowerName.includes('border') ||
-        isColorValue(value)
+        lowerName.includes('border')
       ) {
         theme.colors[name] = value;
       } else if (
@@ -122,13 +127,11 @@ export async function handleGetThemeInfo(input: any) {
         lowerName.includes('spacing') ||
         lowerName.includes('margin') ||
         lowerName.includes('padding') ||
-        lowerName.includes('gap') ||
-        isSpacingValue(value)
+        lowerName.includes('gap')
       ) {
         theme.spacing[name] = value;
       } else if (
         lowerName.includes('font') ||
-        lowerName.includes('text') ||
         lowerName.includes('line') ||
         lowerName.includes('letter')
       ) {
@@ -143,6 +146,10 @@ export async function handleGetThemeInfo(input: any) {
         theme.shadows[name] = value;
       } else if (lowerName.includes('radius') || lowerName.includes('rounded')) {
         theme.radii[name] = value;
+      } else if (isColorValue(value)) {
+        theme.colors[name] = value;
+      } else if (isSpacingValue(value)) {
+        theme.spacing[name] = value;
       } else if (includeAll) {
         // If includeAll is true, add uncategorized tokens to a special category
         if (!(theme as any).other) {

--- a/src/utils/error-formatter.ts
+++ b/src/utils/error-formatter.ts
@@ -83,10 +83,16 @@ export function formatError(
     message += `\n\n${contextDetails.join(', ')}`;
   }
 
-  // Add debug information in development
-  if (includeDebug && originalError) {
-    const debugInfo = typeof originalError === 'string' ? originalError : originalError.message;
-    message += `\nDebug: ${debugInfo}`;
+  // Always surface what actually went wrong. The category templates are
+  // generic by design, so on their own they can be flatly wrong: a pagination
+  // error ("Page 9 exceeds total pages (3)") fell through to the connection
+  // template and told the caller Storybook was unreachable. The caller here is
+  // usually a model, which then goes and debugs the wrong thing.
+  if (originalError) {
+    const details = typeof originalError === 'string' ? originalError : originalError.message;
+    if (details) {
+      message += `\nDetails: ${details}`;
+    }
   }
 
   // Add troubleshooting steps

--- a/src/utils/html-css-parser.ts
+++ b/src/utils/html-css-parser.ts
@@ -168,13 +168,21 @@ export function parseCSSRules(css: string): CSSRule[] {
     const styleBlock = match[2];
 
     const styles: Record<string, string> = {};
-    const propertyRegex = /([^:]+):\s*([^;]+)/g;
-    let propMatch;
 
-    while ((propMatch = propertyRegex.exec(styleBlock)) !== null) {
-      if (propMatch[1] && propMatch[2]) {
-        const property = propMatch[1].trim();
-        const value = propMatch[2].trim();
+    // Split on the declaration separator first. Running a single
+    // `([^:]+):\s*([^;]+)` regex across the whole block swallowed the
+    // separator into the next property name, so `color: red; padding: 4px`
+    // produced a key of `; padding` for everything after the first
+    // declaration.
+    for (const declaration of styleBlock.split(';')) {
+      const separator = declaration.indexOf(':');
+      if (separator === -1) {
+        continue;
+      }
+
+      const property = declaration.slice(0, separator).trim();
+      const value = declaration.slice(separator + 1).trim();
+      if (property && value) {
         styles[property] = value;
       }
     }

--- a/tests/helpers/storybook-fixture.ts
+++ b/tests/helpers/storybook-fixture.ts
@@ -1,0 +1,85 @@
+import { vi } from 'vitest';
+
+import type { ComponentHTML } from '../../src/types/storybook.js';
+
+export interface FixtureStory {
+  id: string;
+  title: string;
+  name: string;
+}
+
+/**
+ * A small but representative Storybook index: two variants of one component,
+ * a nested category, and a story with no category at all.
+ */
+export const STORY_ENTRIES: Record<string, FixtureStory> = {
+  'components-button--primary': {
+    id: 'components-button--primary',
+    title: 'Components/Button',
+    name: 'Primary',
+  },
+  'components-button--default': {
+    id: 'components-button--default',
+    title: 'Components/Button',
+    name: 'Default',
+  },
+  'components-forms-input--default': {
+    id: 'components-forms-input--default',
+    title: 'Components/Forms/Input',
+    name: 'Default',
+  },
+  'alert--danger': { id: 'alert--danger', title: 'Alert', name: 'Danger' },
+};
+
+export const COMPONENT_HTML: ComponentHTML = {
+  storyId: 'components-button--primary',
+  html: '<button class="btn btn--primary">Click me</button>',
+  styles: ['.sb-show-main { padding: 0; }', '.btn { color: red; }'],
+  classes: ['btn', 'btn--primary'],
+};
+
+export interface StorybookClientStub {
+  fetchStoriesIndex: ReturnType<typeof vi.fn>;
+  fetchComponentHTML: ReturnType<typeof vi.fn>;
+  getStorybookUrl: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Fresh stub per test. `StorybookClient` is constructed inside the handlers,
+ * so the module mock has to hand back whichever stub the current test set up.
+ */
+export function createStorybookClientStub(): StorybookClientStub {
+  return {
+    fetchStoriesIndex: vi.fn().mockResolvedValue({ v: 5, entries: STORY_ENTRIES }),
+    fetchComponentHTML: vi.fn().mockResolvedValue(COMPONENT_HTML),
+    getStorybookUrl: vi.fn().mockReturnValue('http://localhost:6006'),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * A stand-in `StorybookClient` that forwards to whatever stub the current test
+ * installed. The job queue caches its client for the lifetime of the process,
+ * so returning the stub object directly would pin the very first test's stub
+ * into the singleton and every later test would assert against a dead mock.
+ */
+export function delegatingClient(current: () => StorybookClientStub) {
+  return {
+    fetchStoriesIndex: (...args: any[]) => current().fetchStoriesIndex(...args),
+    fetchComponentHTML: (...args: any[]) => current().fetchComponentHTML(...args),
+    getStorybookUrl: (...args: any[]) => current().getStorybookUrl(...args),
+    close: (...args: any[]) => current().close(...args),
+  };
+}
+
+/** Parse the JSON payload a tool response carries after its message line. */
+export function parseToolResponse(response: { content: Array<{ text: string }> }): any {
+  const text = response.content[0]!.text;
+  const start = text.indexOf('\n\n');
+  return JSON.parse(start === -1 ? text : text.slice(start + 2));
+}
+
+export function responseText(response: { content: Array<{ text: string }> }): string {
+  return response.content[0]!.text;
+}

--- a/tests/unit/services/job-queue.test.ts
+++ b/tests/unit/services/job-queue.test.ts
@@ -6,6 +6,7 @@ import {
   COMPONENT_HTML,
   type StorybookClientStub,
 } from '../../helpers/storybook-fixture.js';
+import { getEnvironmentTimeout } from '../../../src/utils/timeout-constants.js';
 
 let stub: StorybookClientStub;
 
@@ -144,16 +145,22 @@ describe('jobQueue.runSync', () => {
   });
 
   it('times out a fetch that never resolves', async () => {
+    // The requested timeout is scaled by the environment — CI gets 1.5× — so
+    // the deadline has to be derived, not hardcoded, or this hangs on CI and
+    // passes locally.
+    const requested = 5000;
+    const effective = getEnvironmentTimeout(requested);
+
     vi.useFakeTimers();
     stub.fetchComponentHTML.mockReturnValue(new Promise(() => {}));
 
     const pending = jobQueue.runSync('get_component_html', {
       componentId: 'components-button--primary',
-      timeout: 5000,
+      timeout: requested,
     });
-    const assertion = expect(pending).rejects.toThrow('Operation timed out after 5000ms');
+    const assertion = expect(pending).rejects.toThrow(`Operation timed out after ${effective}ms`);
 
-    await vi.advanceTimersByTimeAsync(5001);
+    await vi.advanceTimersByTimeAsync(effective + 1);
     await assertion;
     vi.useRealTimers();
   });

--- a/tests/unit/services/job-queue.test.ts
+++ b/tests/unit/services/job-queue.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  COMPONENT_HTML,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { jobQueue } = await import('../../../src/services/job-queue.js');
+
+/** Let the queue's fire-and-forget processing settle. */
+const settle = async () => {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+};
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('jobQueue.enqueue', () => {
+  it('returns a unique id and starts the job queued', () => {
+    const first = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    const second = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^job_\d+_[a-z0-9]+$/);
+  });
+
+  it('runs the job and stores the result', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const status = jobQueue.getStatus(jobId)!;
+    expect(status.status).toBe('completed');
+    expect(status.result.html).toBe(COMPONENT_HTML.html);
+    expect(status.started_at).toBeDefined();
+    expect(status.completed_at).toBeDefined();
+  });
+
+  it('records the failure message instead of throwing', async () => {
+    stub.fetchComponentHTML.mockRejectedValue(new Error('Navigation timeout'));
+
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const status = jobQueue.getStatus(jobId)!;
+    expect(status.status).toBe('failed');
+    expect(status.error).toBe('Navigation timeout');
+  });
+
+  it('fails a job for an unknown tool', async () => {
+    const jobId = jobQueue.enqueue('does_not_exist', { componentId: 'x' });
+    await settle();
+
+    expect(jobQueue.getStatus(jobId)!.error).toBe('Unknown tool: does_not_exist');
+  });
+});
+
+describe('jobQueue.getStatus', () => {
+  it('returns null for an unknown id', () => {
+    expect(jobQueue.getStatus('job_nope')).toBeNull();
+  });
+
+  it('omits result and error until there is one', () => {
+    const jobId = jobQueue.enqueue('get_component_html', { componentId: 'alert--danger' });
+    const status = jobQueue.getStatus(jobId)!;
+
+    expect(status.job_id).toBe(jobId);
+    expect(status).not.toHaveProperty('result');
+    expect(status).not.toHaveProperty('error');
+  });
+});
+
+describe('jobQueue.cancel', () => {
+  it('reports false for an unknown id', () => {
+    expect(jobQueue.cancel('job_nope')).toBe(false);
+  });
+
+  it('reports false for a job that already finished', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    expect(jobQueue.getStatus(jobId)!.status).toBe('completed');
+    expect(jobQueue.cancel(jobId)).toBe(false);
+  });
+
+  it('discards the result of a job cancelled mid-flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    stub.fetchComponentHTML.mockReturnValue(
+      new Promise(resolve => {
+        release = resolve;
+      })
+    );
+
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+    expect(jobQueue.getStatus(jobId)!.status).toBe('running');
+
+    expect(jobQueue.cancel(jobId)).toBe(true);
+    release(COMPONENT_HTML);
+    await settle();
+
+    const status = jobQueue.getStatus(jobId)!;
+    expect(status.status).toBe('cancelled');
+    expect(status).not.toHaveProperty('result');
+  });
+});
+
+describe('jobQueue.runSync', () => {
+  it('resolves the component id to a story before fetching', async () => {
+    const result = await jobQueue.runSync('get_component_html', {
+      componentId: 'components-button',
+    });
+
+    expect(stub.fetchComponentHTML).toHaveBeenCalledWith('components-button--default');
+    expect(result.storyId).toBe(COMPONENT_HTML.storyId);
+  });
+
+  it('rejects an unknown tool', async () => {
+    await expect(jobQueue.runSync('nope', {})).rejects.toThrow('Unknown tool: nope');
+  });
+
+  it('times out a fetch that never resolves', async () => {
+    vi.useFakeTimers();
+    stub.fetchComponentHTML.mockReturnValue(new Promise(() => {}));
+
+    const pending = jobQueue.runSync('get_component_html', {
+      componentId: 'components-button--primary',
+      timeout: 5000,
+    });
+    const assertion = expect(pending).rejects.toThrow('Operation timed out after 5000ms');
+
+    await vi.advanceTimersByTimeAsync(5001);
+    await assertion;
+    vi.useRealTimers();
+  });
+});
+
+describe('jobQueue.listJobs and getStats', () => {
+  it('filters by lifecycle state', async () => {
+    const done = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const completed = jobQueue.listJobs('completed').map(j => j.job_id);
+    expect(completed).toContain(done);
+    expect(jobQueue.listJobs('active').map(j => j.job_id)).not.toContain(done);
+    expect(jobQueue.listJobs('all').map(j => j.job_id)).toContain(done);
+  });
+
+  it('reports the component each job is working on', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', { componentId: 'alert--danger' });
+    await settle();
+
+    expect(jobQueue.listJobs('all').find(j => j.job_id === jobId)!.component_id).toBe(
+      'alert--danger'
+    );
+  });
+
+  it('counts cancelled jobs as failed in the stats', async () => {
+    const before = jobQueue.getStats();
+    const jobId = jobQueue.enqueue('get_component_html', { componentId: 'alert--danger' });
+    jobQueue.cancel(jobId);
+    await settle();
+
+    expect(jobQueue.getStats().failed).toBe(before.failed + 1);
+  });
+});

--- a/tests/unit/tools/get-component-dependencies.test.ts
+++ b/tests/unit/tools/get-component-dependencies.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleGetComponentDependencies } =
+  await import('../../../src/tools/get-component-dependencies.js');
+
+const withHTML = (html: string) => {
+  stub.fetchComponentHTML.mockResolvedValue({
+    storyId: 'card--default',
+    html,
+    styles: [],
+    classes: [],
+  });
+  return handleGetComponentDependencies({ componentId: 'card--default' });
+};
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('handleGetComponentDependencies', () => {
+  it('finds React-style, web and framework components', async () => {
+    const data = parseToolResponse(
+      await withHTML(
+        '<Card><CardHeader /><my-avatar size="s"></my-avatar><app-footer></app-footer></Card>'
+      )
+    );
+
+    expect(data.dependencies).toEqual(['Card', 'CardHeader', 'app-footer', 'my-avatar']);
+  });
+
+  it('ignores plain HTML elements', async () => {
+    const data = parseToolResponse(
+      await withHTML('<div><span><button type="button">x</button><svg><path /></svg></span></div>')
+    );
+
+    expect(data.dependencies).toEqual([]);
+  });
+
+  it('splits library components out from in-house ones', async () => {
+    const data = parseToolResponse(
+      await withHTML('<MuiButton /><AntTable /><Card /><BootstrapModal />')
+    );
+
+    expect(data.externalComponents).toEqual(['AntTable', 'BootstrapModal', 'MuiButton']);
+    // "Button" is the Mui prefix stripped off MuiButton by the class-name
+    // heuristic; it is reported alongside the tag it came from.
+    expect(data.internalComponents).toEqual(['Button', 'Card']);
+  });
+
+  it('infers components from class-name conventions', async () => {
+    const data = parseToolResponse(
+      await withHTML(
+        '<div class="MuiPaper-root"><span class="Button-root"></span><i class="component-icon"></i></div>'
+      )
+    );
+
+    // `MuiPaper-root` yields both the full name and the Mui-stripped one.
+    expect(data.dependencies).toEqual(['Button', 'MuiPaper', 'Paper', 'icon']);
+  });
+
+  it('de-duplicates repeated usages', async () => {
+    const data = parseToolResponse(await withHTML('<Chip /><Chip /><Chip />'));
+
+    expect(data.dependencies).toEqual(['Chip']);
+  });
+
+  it('echoes the story id it analysed', async () => {
+    const data = parseToolResponse(await withHTML('<Card />'));
+
+    expect(data.storyId).toBe('card--default');
+  });
+
+  it('requires componentId', async () => {
+    expect(responseText(await handleGetComponentDependencies({}))).toMatch(/^Error:/);
+  });
+
+  it('surfaces a fetch failure as an error response', async () => {
+    stub.fetchComponentHTML.mockRejectedValue(new Error('Story not found'));
+
+    expect(
+      responseText(await handleGetComponentDependencies({ componentId: 'ghost--default' }))
+    ).toBe('Error: Story not found');
+  });
+});

--- a/tests/unit/tools/get-component-html.test.ts
+++ b/tests/unit/tools/get-component-html.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleGetComponentHTML, getComponentHTMLTool } =
+  await import('../../../src/tools/get-component-html.js');
+const { jobQueue } = await import('../../../src/services/job-queue.js');
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('get_component_html tool definition', () => {
+  it('requires only componentId', () => {
+    expect(getComponentHTMLTool.inputSchema.required).toEqual(['componentId']);
+  });
+});
+
+describe('handleGetComponentHTML — variantsOnly', () => {
+  it('lists the variants of a component id', async () => {
+    const data = parseToolResponse(
+      await handleGetComponentHTML({ componentId: 'components-button', variantsOnly: true })
+    );
+
+    expect(data.componentId).toBe('components-button');
+    expect(data.variants.sort()).toEqual(['default', 'primary']);
+  });
+
+  it('matches the component id case-insensitively', async () => {
+    const data = parseToolResponse(
+      await handleGetComponentHTML({ componentId: 'COMPONENTS-BUTTON', variantsOnly: true })
+    );
+
+    expect(data.variants).toHaveLength(2);
+  });
+
+  it('does not match a different component with a shared prefix', async () => {
+    const text = responseText(
+      await handleGetComponentHTML({ componentId: 'components', variantsOnly: true })
+    );
+
+    expect(text).toContain('No variants found for component: components');
+  });
+
+  it('reports an unknown component', async () => {
+    const text = responseText(
+      await handleGetComponentHTML({ componentId: 'nope', variantsOnly: true })
+    );
+
+    expect(text).toMatch(/^Error:/);
+    expect(text).toContain('No variants found for component: nope');
+  });
+
+  it('never touches the browser path', async () => {
+    await handleGetComponentHTML({ componentId: 'alert', variantsOnly: true });
+
+    expect(stub.fetchComponentHTML).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleGetComponentHTML — async mode', () => {
+  it('defaults to async and returns a queued job', async () => {
+    const data = parseToolResponse(
+      await handleGetComponentHTML({ componentId: 'components-button--primary' })
+    );
+
+    expect(data.job_id).toMatch(/^job_/);
+    expect(data.status).toBe('queued');
+    expect(data.component_id).toBe('components-button--primary');
+  });
+
+  it('hands the job id to job_status', async () => {
+    const { job_id } = parseToolResponse(
+      await handleGetComponentHTML({ componentId: 'components-button--primary' })
+    );
+
+    expect(jobQueue.getStatus(job_id)).not.toBeNull();
+  });
+});
+
+describe('handleGetComponentHTML — sync mode', () => {
+  it('returns the extracted HTML and classes', async () => {
+    const data = parseToolResponse(
+      await handleGetComponentHTML({ componentId: 'components-button--primary', async: false })
+    );
+
+    expect(data.storyId).toBe('components-button--primary');
+    expect(data.html).toBe('<button class="btn btn--primary">Click me</button>');
+    expect(data.classes).toEqual(['btn', 'btn--primary']);
+  });
+
+  it('omits styles unless asked', async () => {
+    const data = parseToolResponse(
+      await handleGetComponentHTML({ componentId: 'components-button--primary', async: false })
+    );
+
+    expect(data).not.toHaveProperty('styles');
+  });
+
+  it('filters Storybook boilerplate out of the returned styles', async () => {
+    const data = parseToolResponse(
+      await handleGetComponentHTML({
+        componentId: 'components-button--primary',
+        async: false,
+        includeStyles: true,
+      })
+    );
+
+    expect(data.styles).toEqual(['.btn { color: red; }']);
+  });
+
+  it('resolves a bare component id, preferring the --default story', async () => {
+    await handleGetComponentHTML({ componentId: 'components-button', async: false });
+
+    expect(stub.fetchComponentHTML).toHaveBeenCalledWith('components-button--default');
+  });
+
+  it('falls back to the first story when there is no --default', async () => {
+    await handleGetComponentHTML({ componentId: 'alert', async: false });
+
+    expect(stub.fetchComponentHTML).toHaveBeenCalledWith('alert--danger');
+  });
+
+  it('reports a component with no stories', async () => {
+    const text = responseText(await handleGetComponentHTML({ componentId: 'ghost', async: false }));
+
+    expect(text).toContain('No stories found for component: ghost');
+  });
+
+  it('surfaces an extraction failure as an error response', async () => {
+    stub.fetchComponentHTML.mockRejectedValue(new Error('Navigation timeout'));
+
+    const text = responseText(
+      await handleGetComponentHTML({ componentId: 'components-button--primary', async: false })
+    );
+
+    expect(text).toMatch(/^Error:/);
+    expect(text).toContain('Navigation timeout');
+  });
+});
+
+describe('handleGetComponentHTML — validation', () => {
+  it('requires componentId', async () => {
+    expect(responseText(await handleGetComponentHTML({}))).toMatch(/^Error:/);
+  });
+
+  it('rejects a timeout outside the documented range', async () => {
+    expect(
+      responseText(await handleGetComponentHTML({ componentId: 'alert', timeout: 100 }))
+    ).toMatch(/^Error:/);
+    expect(
+      responseText(await handleGetComponentHTML({ componentId: 'alert', timeout: 600000 }))
+    ).toMatch(/^Error:/);
+  });
+
+  it('names the component in the error context when validation passes', async () => {
+    stub.fetchStoriesIndex.mockRejectedValue(new Error('boom'));
+
+    expect(
+      responseText(await handleGetComponentHTML({ componentId: 'alert', variantsOnly: true }))
+    ).toContain('alert');
+  });
+});

--- a/tests/unit/tools/get-external-css.test.ts
+++ b/tests/unit/tools/get-external-css.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleGetExternalCSS } = await import('../../../src/tools/get-external-css.js');
+
+const CSS = `:root {
+  --color-primary: #0055ff;
+  --spacing-md: 16px;
+  --font-family-base: Inter, sans-serif;
+  --shadow-card: 0 1px 2px rgba(0,0,0,.1);
+  --border-style: solid;
+  --breakpoint-lg: xl;
+  --transition-fast: ease-in;
+}
+.btn { color: var(--color-primary); padding: var(--spacing-md); }
+@media (min-width: 40em) { .btn { display: block; } }`;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+const cssResponse = (body: string) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  text: async () => body,
+});
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+  fetchMock = vi.fn().mockResolvedValue(cssResponse(CSS));
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('handleGetExternalCSS — URL handling', () => {
+  it('resolves a relative path against the Storybook URL', async () => {
+    const data = parseToolResponse(await handleGetExternalCSS({ cssUrl: '/assets/main.css' }));
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://localhost:6006/assets/main.css');
+    expect(data.url).toBe('http://localhost:6006/assets/main.css');
+    expect(data.originalUrl).toBe('/assets/main.css');
+  });
+
+  it('accepts an absolute URL on the Storybook host', async () => {
+    await handleGetExternalCSS({ cssUrl: 'http://localhost:6006/main.css' });
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://localhost:6006/main.css');
+  });
+
+  it('accepts a subdomain of the Storybook host', async () => {
+    stub.getStorybookUrl.mockReturnValue('https://example.com');
+
+    const response = await handleGetExternalCSS({ cssUrl: 'https://cdn.example.com/main.css' });
+
+    expect(responseText(response)).not.toMatch(/^Error:/);
+  });
+
+  it('refuses a third-party host', async () => {
+    const text = responseText(await handleGetExternalCSS({ cssUrl: 'https://evil.test/main.css' }));
+
+    expect(text).toMatch(/^Error:/);
+    expect(text).toContain('[SECURITY_ERROR]');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a lookalike host that merely ends with the same string', async () => {
+    stub.getStorybookUrl.mockReturnValue('https://example.com');
+
+    const text = responseText(
+      await handleGetExternalCSS({ cssUrl: 'https://notexample.com/main.css' })
+    );
+
+    expect(text).toContain('[SECURITY_ERROR]');
+  });
+
+  it('requires a cssUrl', async () => {
+    expect(responseText(await handleGetExternalCSS({}))).toMatch(/^Error:/);
+    expect(responseText(await handleGetExternalCSS({ cssUrl: '' }))).toMatch(/^Error:/);
+    expect(responseText(await handleGetExternalCSS(null))).toMatch(/^Error:/);
+  });
+});
+
+describe('handleGetExternalCSS — response shape', () => {
+  it('returns tokens and statistics but no CSS by default', async () => {
+    const response = await handleGetExternalCSS({ cssUrl: '/main.css' });
+    const data = parseToolResponse(response);
+
+    expect(data).not.toHaveProperty('content');
+    expect(data.tokensExtracted).toBe(true);
+    expect(data.tokenCount).toBe(7);
+    expect(responseText(response)).toContain('CSS content NOT included');
+  });
+
+  it('sorts tokens into buckets', async () => {
+    const { tokens } = parseToolResponse(await handleGetExternalCSS({ cssUrl: '/main.css' }));
+
+    expect(tokens.colors).toEqual({ '--color-primary': '#0055ff' });
+    expect(tokens.spacing).toEqual({ '--spacing-md': '16px' });
+    expect(tokens.typography).toEqual({ '--font-family-base': 'Inter, sans-serif' });
+    expect(tokens.shadows).toEqual({ '--shadow-card': '0 1px 2px rgba(0,0,0,.1)' });
+    expect(tokens.radii).toEqual({ '--border-style': 'solid' });
+    expect(tokens.breakpoints).toEqual({ '--breakpoint-lg': 'xl' });
+    expect(tokens.other).toEqual({ '--transition-fast': 'ease-in' });
+  });
+
+  it('can skip token extraction', async () => {
+    const data = parseToolResponse(
+      await handleGetExternalCSS({ cssUrl: '/main.css', extractTokens: false })
+    );
+
+    expect(data.tokensExtracted).toBe(false);
+    expect(data.tokenCount).toBe(0);
+    expect(data.tokens).toBeNull();
+    // Statistics are computed either way.
+    expect(data.analysis.customProperties).toBe(7);
+  });
+
+  it('reports rule, media-query and declaration counts', async () => {
+    const { analysis } = parseToolResponse(await handleGetExternalCSS({ cssUrl: '/main.css' }));
+
+    expect(analysis.mediaQueries).toBe(1);
+    expect(analysis.totalRules).toBeGreaterThan(0);
+    expect(analysis.declarations).toBeGreaterThan(0);
+  });
+
+  it('formats the file size in human units', async () => {
+    fetchMock.mockResolvedValue(cssResponse('a'.repeat(2048)));
+
+    const data = parseToolResponse(await handleGetExternalCSS({ cssUrl: '/main.css' }));
+
+    expect(data.fileSize).toBe(2048);
+    expect(data.fileSizeFormatted).toBe('2 KB');
+  });
+
+  it('reports an empty file as 0 Bytes', async () => {
+    fetchMock.mockResolvedValue(cssResponse(''));
+
+    expect(
+      parseToolResponse(await handleGetExternalCSS({ cssUrl: '/main.css' })).fileSizeFormatted
+    ).toBe('0 Bytes');
+  });
+});
+
+describe('handleGetExternalCSS — full CSS mode', () => {
+  it('returns the whole file when it fits', async () => {
+    const data = parseToolResponse(
+      await handleGetExternalCSS({ cssUrl: '/main.css', includeFullCSS: true })
+    );
+
+    expect(data.content).toBe(CSS);
+    expect(data.truncated).toBe(false);
+    expect(data.displayedSize).toBe(CSS.length);
+  });
+
+  it('truncates past maxContentSize and says so', async () => {
+    const data = parseToolResponse(
+      await handleGetExternalCSS({ cssUrl: '/main.css', includeFullCSS: true, maxContentSize: 20 })
+    );
+
+    expect(data.truncated).toBe(true);
+    expect(data.displayedSize).toBe(20);
+    expect(data.content).toContain('Content truncated due to size limit');
+    expect(data.truncationWarning).toContain('Use maxContentSize parameter');
+  });
+
+  it('flags truncation in the summary line too', async () => {
+    const text = responseText(
+      await handleGetExternalCSS({ cssUrl: '/main.css', includeFullCSS: true, maxContentSize: 20 })
+    );
+
+    expect(text).toContain('TRUNCATED due to size');
+    expect(text).toContain('design tokens extracted');
+  });
+});
+
+describe('handleGetExternalCSS — failures', () => {
+  it('reports an HTTP failure with its status', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const text = responseText(await handleGetExternalCSS({ cssUrl: '/missing.css' }));
+
+    expect(text).toContain('Status: 404');
+  });
+
+  it('reports a network failure', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    expect(responseText(await handleGetExternalCSS({ cssUrl: '/main.css' }))).toContain(
+      'connect ECONNREFUSED'
+    );
+  });
+
+  it('names an aborted request as a timeout', async () => {
+    fetchMock.mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+
+    expect(responseText(await handleGetExternalCSS({ cssUrl: '/main.css' }))).toContain(
+      '[TIMEOUT_ERROR]'
+    );
+  });
+});

--- a/tests/unit/tools/get-theme-info.test.ts
+++ b/tests/unit/tools/get-theme-info.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleGetThemeInfo } = await import('../../../src/tools/get-theme-info.js');
+
+const indexWith = (entries: Record<string, { title: string; name: string }>) => {
+  stub.fetchStoriesIndex.mockResolvedValue({
+    v: 5,
+    entries: Object.fromEntries(
+      Object.entries(entries).map(([id, story]) => [id, { id, ...story }])
+    ),
+  });
+};
+
+const htmlWith = (styles: string[], html = '<div></div>') => {
+  stub.fetchComponentHTML.mockResolvedValue({ storyId: 'x', html, styles, classes: [] });
+};
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('handleGetThemeInfo', () => {
+  it('prefers a theme-ish story over the first one in the index', async () => {
+    indexWith({
+      'components-button--primary': { title: 'Components/Button', name: 'Primary' },
+      'foundation-colors--all': { title: 'Foundation/Colors', name: 'All' },
+    });
+    htmlWith([':root { --color-primary: #0055ff; }']);
+
+    const data = parseToolResponse(await handleGetThemeInfo({}));
+
+    expect(data.sourceStoryId).toBe('foundation-colors--all');
+    expect(stub.fetchComponentHTML).toHaveBeenCalledWith('foundation-colors--all');
+  });
+
+  it('falls back to the first story when nothing looks like a theme', async () => {
+    indexWith({
+      'components-button--primary': { title: 'Components/Button', name: 'Primary' },
+      'components-card--default': { title: 'Components/Card', name: 'Default' },
+    });
+    htmlWith([]);
+
+    expect(parseToolResponse(await handleGetThemeInfo({})).sourceStoryId).toBe(
+      'components-button--primary'
+    );
+  });
+
+  it('sorts tokens into theme buckets', async () => {
+    indexWith({ 'theme--tokens': { title: 'Theme', name: 'Tokens' } });
+    htmlWith([
+      `:root {
+        --color-primary: #0055ff;
+        --spacing-md: 16px;
+        --font-size-body: 14px;
+        --breakpoint-md: 960px;
+        --shadow-card: 0 1px 2px rgba(0,0,0,.1);
+        --radius-sm: 2px;
+      }`,
+    ]);
+
+    const { theme, totalTokens } = parseToolResponse(await handleGetThemeInfo({}));
+
+    expect(totalTokens).toBe(6);
+    expect(theme.colors).toEqual({ '--color-primary': '#0055ff' });
+    expect(theme.spacing).toEqual({ '--spacing-md': '16px' });
+    expect(theme.typography).toEqual({ '--font-size-body': '14px' });
+    expect(theme.breakpoints).toEqual({ '--breakpoint-md': '960px' });
+    expect(theme.shadows).toEqual({ '--shadow-card': '0 1px 2px rgba(0,0,0,.1)' });
+    expect(theme.radii).toEqual({ '--radius-sm': '2px' });
+  });
+
+  it('files a token by its name even when the value looks like spacing', async () => {
+    // Regression: `isSpacingValue` was evaluated inside the spacing branch,
+    // ahead of the breakpoint and radius checks, so any token whose value was
+    // a bare unit ended up as spacing regardless of its name.
+    indexWith({ 'theme--tokens': { title: 'Theme', name: 'Tokens' } });
+    htmlWith([':root { --breakpoint-lg: 1280px; --radius-pill: 999px; }']);
+
+    const { theme } = parseToolResponse(await handleGetThemeInfo({}));
+
+    expect(theme.breakpoints).toEqual({ '--breakpoint-lg': '1280px' });
+    expect(theme.radii).toEqual({ '--radius-pill': '999px' });
+    expect(theme.spacing).toEqual({});
+  });
+
+  it('falls back to the value when the name says nothing', async () => {
+    indexWith({ 'theme--tokens': { title: 'Theme', name: 'Tokens' } });
+    htmlWith([':root { --brand: #0055ff; --gutter: 24px; }']);
+
+    const { theme } = parseToolResponse(await handleGetThemeInfo({}));
+
+    expect(theme.colors).toEqual({ '--brand': '#0055ff' });
+    expect(theme.spacing).toEqual({ '--gutter': '24px' });
+  });
+
+  it('also reads tokens off inline style attributes', async () => {
+    indexWith({ 'theme--tokens': { title: 'Theme', name: 'Tokens' } });
+    htmlWith([], '<div style="--color-accent: #ff0000">x</div>');
+
+    const { theme } = parseToolResponse(await handleGetThemeInfo({}));
+
+    expect(theme.colors).toEqual({ '--color-accent': '#ff0000' });
+  });
+
+  it('substitutes default breakpoints when the design system defines none', async () => {
+    indexWith({ 'theme--tokens': { title: 'Theme', name: 'Tokens' } });
+    htmlWith([':root { --color-primary: #000; }']);
+
+    const { theme } = parseToolResponse(await handleGetThemeInfo({}));
+
+    expect(Object.keys(theme.breakpoints)).toEqual([
+      '--breakpoint-xs',
+      '--breakpoint-sm',
+      '--breakpoint-md',
+      '--breakpoint-lg',
+      '--breakpoint-xl',
+    ]);
+  });
+
+  it('drops uncategorised tokens unless includeAll is set', async () => {
+    indexWith({ 'theme--tokens': { title: 'Theme', name: 'Tokens' } });
+    htmlWith([':root { --transition-fast: 150ms ease; }']);
+
+    expect(parseToolResponse(await handleGetThemeInfo({})).theme.other).toBeUndefined();
+
+    const withAll = parseToolResponse(await handleGetThemeInfo({ includeAll: true }));
+    expect(withAll.theme.other).toEqual({ '--transition-fast': '150ms ease' });
+    // Either way the count reflects everything that was found.
+    expect(withAll.totalTokens).toBe(1);
+  });
+
+  it('reports an index with no stories', async () => {
+    stub.fetchStoriesIndex.mockResolvedValue({ v: 5 } as any);
+
+    expect(responseText(await handleGetThemeInfo({}))).toBe(
+      'Error: No stories found in Storybook index'
+    );
+  });
+
+  it('reports an empty index', async () => {
+    indexWith({});
+
+    expect(responseText(await handleGetThemeInfo({}))).toBe(
+      'Error: No stories available to extract theme information'
+    );
+  });
+
+  it('rejects a non-boolean includeAll', async () => {
+    expect(responseText(await handleGetThemeInfo({ includeAll: 'yes' }))).toMatch(/^Error:/);
+  });
+});

--- a/tests/unit/tools/job-tools.test.ts
+++ b/tests/unit/tools/job-tools.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleJobStatus } = await import('../../../src/tools/job-status.js');
+const { handleJobList } = await import('../../../src/tools/job-list.js');
+const { handleJobCancel } = await import('../../../src/tools/job-cancel.js');
+const { jobQueue } = await import('../../../src/services/job-queue.js');
+
+const settle = async () => {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+};
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('job_status', () => {
+  it('reports a finished job with its result', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const response = await handleJobStatus({ job_id: jobId });
+
+    expect(responseText(response)).toContain('Job completed successfully');
+    expect(parseToolResponse(response).result.classes).toEqual(['btn', 'btn--primary']);
+  });
+
+  it('reports a failed job with its error', async () => {
+    stub.fetchComponentHTML.mockRejectedValue(new Error('Navigation timeout'));
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const response = await handleJobStatus({ job_id: jobId });
+
+    expect(responseText(response)).toContain('Job failed');
+    expect(parseToolResponse(response).error).toBe('Navigation timeout');
+  });
+
+  it('reports an unknown job id as an error', async () => {
+    const text = responseText(await handleJobStatus({ job_id: 'job_missing' }));
+
+    expect(text).toMatch(/^Error:/);
+    expect(text).toContain('Job not found: job_missing');
+  });
+
+  it('requires job_id', async () => {
+    expect(responseText(await handleJobStatus({}))).toMatch(/^Error:/);
+  });
+});
+
+describe('job_cancel', () => {
+  it('cancels a queued job', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', { componentId: 'alert--danger' });
+
+    const data = parseToolResponse(await handleJobCancel({ job_id: jobId }));
+
+    expect(data).toEqual({ job_id: jobId, cancelled: true });
+    expect(jobQueue.getStatus(jobId)!.status).toBe('cancelled');
+    await settle();
+  });
+
+  it('reports a job it could not cancel without failing the call', async () => {
+    const response = await handleJobCancel({ job_id: 'job_missing' });
+
+    expect(responseText(response)).not.toMatch(/^Error:/);
+    expect(parseToolResponse(response).cancelled).toBe(false);
+  });
+
+  it('requires job_id', async () => {
+    expect(responseText(await handleJobCancel({}))).toMatch(/^Error:/);
+  });
+});
+
+describe('job_list', () => {
+  it('lists jobs with queue statistics', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const response = await handleJobList({});
+    const data = parseToolResponse(response);
+
+    expect(data.jobs.map((j: any) => j.job_id)).toContain(jobId);
+    expect(data.stats).toEqual({
+      queued: expect.any(Number),
+      running: expect.any(Number),
+      completed: expect.any(Number),
+      failed: expect.any(Number),
+    });
+    expect(responseText(response)).toMatch(/^Found \d+ jobs/);
+  });
+
+  it('defaults to all jobs when called with no arguments', async () => {
+    const all = parseToolResponse(await handleJobList({})).jobs.length;
+
+    expect(parseToolResponse(await handleJobList(undefined)).jobs).toHaveLength(all);
+  });
+
+  it('filters to completed jobs only', async () => {
+    const jobId = jobQueue.enqueue('get_component_html', {
+      componentId: 'components-button--primary',
+    });
+    await settle();
+
+    const active = parseToolResponse(await handleJobList({ status: 'active' })).jobs;
+    const completed = parseToolResponse(await handleJobList({ status: 'completed' })).jobs;
+
+    expect(completed.map((j: any) => j.job_id)).toContain(jobId);
+    expect(active.map((j: any) => j.job_id)).not.toContain(jobId);
+  });
+
+  it('rejects an unknown status filter', async () => {
+    expect(responseText(await handleJobList({ status: 'pending' }))).toMatch(/^Error:/);
+  });
+});

--- a/tests/unit/tools/list-components.test.ts
+++ b/tests/unit/tools/list-components.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleListComponents, listComponentsTool } =
+  await import('../../../src/tools/list-components.js');
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('list_components tool definition', () => {
+  it('takes no required input', () => {
+    expect(listComponentsTool.name).toBe('list_components');
+    expect(listComponentsTool.inputSchema.required).toEqual([]);
+  });
+});
+
+describe('handleListComponents', () => {
+  it('returns every component in compact form by default', async () => {
+    const data = parseToolResponse(await handleListComponents({}));
+
+    expect(data).toEqual([
+      { id: 'alert', name: 'Alert', title: 'Alert', variantCount: 1 },
+      {
+        id: 'components-button',
+        name: 'Button',
+        title: 'Components/Button',
+        category: 'Components',
+        variantCount: 2,
+      },
+      {
+        id: 'components-forms-input',
+        name: 'Input',
+        title: 'Components/Forms/Input',
+        category: 'Components/Forms',
+        variantCount: 1,
+      },
+    ]);
+  });
+
+  it('includes the underlying stories when compact is false', async () => {
+    const data = parseToolResponse(await handleListComponents({ compact: false }));
+
+    expect(data[1].stories).toHaveLength(2);
+    expect(data[1].stories[0]).toMatchObject({ id: 'components-button--primary' });
+  });
+
+  it('filters by exact category', async () => {
+    const data = parseToolResponse(await handleListComponents({ category: 'Components' }));
+
+    expect(data.map((c: any) => c.name)).toEqual(['Button']);
+  });
+
+  it('treats category "all" as no filter', async () => {
+    const data = parseToolResponse(await handleListComponents({ category: 'all' }));
+
+    expect(data).toHaveLength(3);
+  });
+
+  it('returns an empty list for a category nothing matches', async () => {
+    const data = parseToolResponse(await handleListComponents({ category: 'Nope' }));
+
+    expect(data).toEqual([]);
+  });
+
+  it('paginates and reports the page in the message', async () => {
+    const response = await handleListComponents({ page: 2, pageSize: 2 });
+
+    expect(responseText(response)).toContain('showing page 2/2');
+    expect(parseToolResponse(response).map((c: any) => c.name)).toEqual(['Input']);
+  });
+
+  it('reports a page past the end as a failure rather than empty data', async () => {
+    const text = responseText(await handleListComponents({ page: 9, pageSize: 2 }));
+
+    expect(text).toMatch(/^Error:/);
+    expect(text).toContain('exceeds total pages');
+  });
+
+  it('rejects a page size over the documented maximum', async () => {
+    const text = responseText(await handleListComponents({ pageSize: 500 }));
+
+    expect(text).toMatch(/^Error:/);
+    expect(stub.fetchStoriesIndex).not.toHaveBeenCalled();
+  });
+
+  it('accepts a v3 index keyed under stories', async () => {
+    stub.fetchStoriesIndex.mockResolvedValue({
+      v: 3,
+      stories: { 'alert--danger': { id: 'alert--danger', title: 'Alert', name: 'Danger' } },
+    });
+
+    expect(parseToolResponse(await handleListComponents({}))).toHaveLength(1);
+  });
+
+  it('explains an index with neither stories nor entries', async () => {
+    stub.fetchStoriesIndex.mockResolvedValue({ v: 5 } as any);
+
+    expect(responseText(await handleListComponents({}))).toContain('Invalid stories index');
+  });
+
+  it('reports an empty Storybook with its URL', async () => {
+    stub.fetchStoriesIndex.mockResolvedValue({ v: 5, entries: {} });
+    const response = await handleListComponents({});
+
+    expect(responseText(response)).toContain('No components found');
+    expect(responseText(response)).toContain('http://localhost:6006');
+    expect(parseToolResponse(response)).toEqual([]);
+  });
+
+  it('surfaces a fetch failure as an error response, not a throw', async () => {
+    stub.fetchStoriesIndex.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:6006'));
+
+    expect(responseText(await handleListComponents({}))).toMatch(/^Error:/);
+  });
+});

--- a/tests/unit/tools/search-components.test.ts
+++ b/tests/unit/tools/search-components.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  parseToolResponse,
+  responseText,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const { handleSearchComponents } = await import('../../../src/tools/search-components.js');
+
+const names = (response: any) => {
+  const data = parseToolResponse(response);
+  return (Array.isArray(data) ? data : data.components).map((c: any) => c.name);
+};
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('handleSearchComponents', () => {
+  it('matches on name, title or category by default', async () => {
+    expect(names(await handleSearchComponents({ query: 'button' }))).toEqual(['Button']);
+    expect(names(await handleSearchComponents({ query: 'forms' }))).toEqual(['Input']);
+  });
+
+  it('is case-insensitive and matches partial words', async () => {
+    expect(names(await handleSearchComponents({ query: 'BUT' }))).toEqual(['Button']);
+  });
+
+  it('honours searchIn: name', async () => {
+    // "Components" is in every title but in no component name.
+    expect(names(await handleSearchComponents({ query: 'Components', searchIn: 'name' }))).toEqual(
+      []
+    );
+    expect(names(await handleSearchComponents({ query: 'Components', searchIn: 'title' }))).toEqual(
+      ['Button', 'Input']
+    );
+  });
+
+  it('honours searchIn: category and skips uncategorised components', async () => {
+    const result = names(
+      await handleSearchComponents({ query: 'components', searchIn: 'category' })
+    );
+
+    expect(result).toEqual(['Button', 'Input']);
+    expect(result).not.toContain('Alert');
+  });
+
+  it('treats * as list-everything', async () => {
+    expect(names(await handleSearchComponents({ query: '*' }))).toEqual([
+      'Alert',
+      'Button',
+      'Input',
+    ]);
+    expect(names(await handleSearchComponents({ query: '.*' }))).toHaveLength(3);
+  });
+
+  it('searches by predefined purpose and returns its description', async () => {
+    const response = await handleSearchComponents({ purpose: 'buttons' });
+    const data = parseToolResponse(response);
+
+    expect(data.description).toBe('Interactive button components');
+    expect(data.components.map((c: any) => c.name)).toEqual(['Button']);
+  });
+
+  it('maps an unknown purpose to word patterns', async () => {
+    const data = parseToolResponse(await handleSearchComponents({ purpose: 'alert danger' }));
+
+    expect(data.description).toBe('Components related to alert danger');
+    expect(data.components.map((c: any) => c.name)).toEqual(['Alert']);
+  });
+
+  it('ANDs query and purpose together', async () => {
+    // "feedback" matches Alert; the query narrows it to nothing.
+    expect(names(await handleSearchComponents({ purpose: 'feedback', query: 'button' }))).toEqual(
+      []
+    );
+    expect(names(await handleSearchComponents({ purpose: 'feedback', query: 'alert' }))).toEqual([
+      'Alert',
+    ]);
+  });
+
+  it('requires either a query or a purpose', async () => {
+    const text = responseText(await handleSearchComponents({}));
+
+    expect(text).toMatch(/^Error:/);
+    expect(text).toContain('Either query or purpose must be provided');
+  });
+
+  it('rejects an empty query with no purpose', async () => {
+    // Passes validation (a string is a string) but there is nothing to match.
+    const text = responseText(await handleSearchComponents({ query: '' }));
+
+    expect(text).toContain('At least one of "query" or "purpose" parameter is required');
+  });
+
+  it('paginates results', async () => {
+    const response = await handleSearchComponents({ query: '*', pageSize: 2 });
+
+    expect(responseText(response)).toContain('showing page 1/2');
+    expect(names(response)).toEqual(['Alert', 'Button']);
+  });
+
+  it('reports no matches as an empty list, not an error', async () => {
+    const response = await handleSearchComponents({ query: 'nonexistent' });
+
+    expect(responseText(response)).not.toMatch(/^Error:/);
+    expect(names(response)).toEqual([]);
+  });
+
+  it('tolerates an index with neither stories nor entries', async () => {
+    stub.fetchStoriesIndex.mockResolvedValue({ v: 5 } as any);
+
+    expect(names(await handleSearchComponents({ query: '*' }))).toEqual([]);
+  });
+
+  it('surfaces a fetch failure as an error response', async () => {
+    stub.fetchStoriesIndex.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    expect(responseText(await handleSearchComponents({ query: '*' }))).toMatch(/^Error:/);
+  });
+});

--- a/tests/unit/utils/cache.test.ts
+++ b/tests/unit/utils/cache.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { Cache } from '../../../src/utils/cache.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Cache', () => {
+  it('returns null for a key that was never set', () => {
+    expect(new Cache().get('missing')).toBeNull();
+  });
+
+  it('round-trips a value', () => {
+    const cache = new Cache();
+    cache.set('stories-index', { entries: { 'button--primary': {} } });
+
+    expect(cache.get<{ entries: Record<string, unknown> }>('stories-index')).toEqual({
+      entries: { 'button--primary': {} },
+    });
+  });
+
+  it('expires an entry once the duration has passed', () => {
+    vi.useFakeTimers();
+    const cache = new Cache(1000);
+    cache.set('key', 'value');
+
+    vi.advanceTimersByTime(999);
+    expect(cache.get('key')).toBe('value');
+
+    vi.advanceTimersByTime(2);
+    expect(cache.get('key')).toBeNull();
+  });
+
+  it('drops the expired entry rather than keeping it around', () => {
+    vi.useFakeTimers();
+    const cache = new Cache(1000);
+    cache.set('key', 'value');
+    vi.advanceTimersByTime(1001);
+
+    expect(cache.size()).toBe(1);
+    cache.get('key');
+    expect(cache.size()).toBe(0);
+  });
+
+  it('refreshes the timestamp when a key is set again', () => {
+    vi.useFakeTimers();
+    const cache = new Cache(1000);
+    cache.set('key', 'first');
+
+    vi.advanceTimersByTime(900);
+    cache.set('key', 'second');
+    vi.advanceTimersByTime(900);
+
+    expect(cache.get('key')).toBe('second');
+  });
+
+  it('clears everything', () => {
+    const cache = new Cache();
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.size()).toBe(2);
+
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.get('a')).toBeNull();
+  });
+});

--- a/tests/unit/utils/error-formatter.test.ts
+++ b/tests/unit/utils/error-formatter.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  formatError,
+  createConnectionError,
+  createNotFoundError,
+  createTimeoutError,
+  createValidationError,
+  createParsingError,
+  createSecurityError,
+  createCertificateError,
+  isSSLCertificateError,
+} from '../../../src/utils/error-formatter.js';
+import { ErrorCategory } from '../../../src/utils/error-constants.js';
+
+describe('formatError', () => {
+  it('leads with the category and the operation context', () => {
+    const { message } = formatError(ErrorCategory.CONNECTION_ERROR, {
+      category: ErrorCategory.CONNECTION_ERROR,
+      operation: 'list components',
+      resource: 'components list',
+    });
+
+    expect(message).toMatch(/^\[CONNECTION_ERROR\]: /);
+    expect(message).toContain('Context: list components for components list');
+    expect(message).toContain('Suggestion: ');
+  });
+
+  it('drops the "for <resource>" clause when there is no resource', () => {
+    const { message } = formatError(ErrorCategory.PARSING_ERROR, {
+      category: ErrorCategory.PARSING_ERROR,
+      operation: 'parse index',
+    });
+
+    expect(message).toContain('Context: parse index\n');
+  });
+
+  it('always includes what actually went wrong', () => {
+    // Regression: the underlying message used to be printed only when
+    // NODE_ENV=development, so in normal use a pagination failure was reported
+    // as "Unable to connect to Storybook" with the real cause thrown away.
+    const { message } = formatError(
+      ErrorCategory.CONNECTION_ERROR,
+      { category: ErrorCategory.CONNECTION_ERROR, operation: 'list components' },
+      new Error('Page 9 exceeds total pages (3).')
+    );
+
+    expect(message).toContain('Details: Page 9 exceeds total pages (3).');
+  });
+
+  it('accepts a plain string as the original error', () => {
+    const { message } = formatError(
+      ErrorCategory.VALIDATION_ERROR,
+      { category: ErrorCategory.VALIDATION_ERROR, operation: 'validate' },
+      'pageSize must be between 1 and 100'
+    );
+
+    expect(message).toContain('Details: pageSize must be between 1 and 100');
+  });
+
+  it('omits the details line when there is nothing to say', () => {
+    const withoutError = formatError(ErrorCategory.NOT_FOUND_ERROR, {
+      category: ErrorCategory.NOT_FOUND_ERROR,
+      operation: 'find story',
+    });
+    const withEmptyError = formatError(
+      ErrorCategory.NOT_FOUND_ERROR,
+      { category: ErrorCategory.NOT_FOUND_ERROR, operation: 'find story' },
+      new Error('')
+    );
+
+    expect(withoutError.message).not.toContain('Details:');
+    expect(withEmptyError.message).not.toContain('Details:');
+  });
+
+  it('lists the context details it was given', () => {
+    const { message } = formatError(ErrorCategory.TIMEOUT_ERROR, {
+      category: ErrorCategory.TIMEOUT_ERROR,
+      operation: 'fetch component HTML',
+      url: 'http://localhost:6006/iframe.html?id=button--primary',
+      storyId: 'button--primary',
+      componentName: 'Button',
+      timeout: 15000,
+      statusCode: 504,
+    });
+
+    expect(message).toContain('URL: http://localhost:6006/iframe.html?id=button--primary');
+    expect(message).toContain('Story ID: button--primary');
+    expect(message).toContain('Component: Button');
+    expect(message).toContain('Timeout: 15000ms');
+    expect(message).toContain('Status: 504');
+  });
+
+  it('appends numbered troubleshooting steps by default', () => {
+    const error = formatError(ErrorCategory.CONNECTION_ERROR, {
+      category: ErrorCategory.CONNECTION_ERROR,
+      operation: 'connect',
+    });
+
+    expect(error.message).toContain('Troubleshooting:');
+    expect(error.troubleshooting?.length).toBeGreaterThan(0);
+  });
+
+  it('can leave troubleshooting out and cap the number of steps', () => {
+    const bare = formatError(
+      ErrorCategory.CONNECTION_ERROR,
+      { category: ErrorCategory.CONNECTION_ERROR, operation: 'connect' },
+      undefined,
+      { includeTroubleshooting: false }
+    );
+    const capped = formatError(
+      ErrorCategory.CONNECTION_ERROR,
+      { category: ErrorCategory.CONNECTION_ERROR, operation: 'connect' },
+      undefined,
+      { maxTroubleshootingSteps: 1 }
+    );
+
+    expect(bare.message).not.toContain('Troubleshooting:');
+    expect(bare.troubleshooting).toBeUndefined();
+    expect(capped.troubleshooting).toHaveLength(1);
+  });
+});
+
+describe('error constructors', () => {
+  it('records the status code on a connection error', () => {
+    const error = createConnectionError(
+      'fetch component HTML',
+      'http://localhost:6006',
+      'boom',
+      503
+    );
+
+    expect(error.category).toBe(ErrorCategory.CONNECTION_ERROR);
+    expect(error.message).toContain('Status: 503');
+    expect(error.message).toContain('Details: boom');
+  });
+
+  it('replaces the default suggestion on a not-found error', () => {
+    const error = createNotFoundError(
+      'fetch component HTML',
+      'story',
+      'Use list_components to find available stories',
+      'button--primary'
+    );
+
+    expect(error.message).toContain('Suggestion: Use list_components to find available stories');
+    expect(error.message).not.toContain('Suggestion: Use list_components or search_components');
+    expect(error.message).toContain('Story ID: button--primary');
+  });
+
+  it('keeps the default suggestion when none is supplied', () => {
+    const error = createNotFoundError('fetch component HTML', 'story');
+
+    expect(error.message).toContain('Suggestion: Use list_components or search_components');
+  });
+
+  it('states the elapsed timeout twice: as context and as the cause', () => {
+    const error = createTimeoutError(
+      'fetch component HTML',
+      15000,
+      'http://localhost:6006',
+      'story'
+    );
+
+    expect(error.message).toContain('Timeout: 15000ms');
+    expect(error.message).toContain('Details: Operation timed out after 15000ms');
+  });
+
+  it('names the offending parameter on a validation error', () => {
+    const error = createValidationError('list components', 'must be 1-100', 'pageSize');
+
+    expect(error.message).toContain('Context: list components for pageSize');
+    expect(error.message).toContain('Details: must be 1-100');
+  });
+
+  it('builds parsing, security and certificate errors in their own category', () => {
+    expect(createParsingError('parse CSS', 'stylesheet').category).toBe(
+      ErrorCategory.PARSING_ERROR
+    );
+    expect(createSecurityError('fetch CSS', 'https://cdn.example.com').category).toBe(
+      ErrorCategory.SECURITY_ERROR
+    );
+    expect(createCertificateError('fetch CSS', 'https://internal.example.com').category).toBe(
+      ErrorCategory.CERTIFICATE_ERROR
+    );
+  });
+});
+
+describe('isSSLCertificateError', () => {
+  it('recognises certificate failures by message', () => {
+    expect(isSSLCertificateError(new Error('self-signed certificate in chain'))).toBe(true);
+    expect(isSSLCertificateError(new Error('unable to verify the first certificate'))).toBe(true);
+    expect(isSSLCertificateError('SSL handshake failed')).toBe(true);
+    expect(isSSLCertificateError('TLS alert')).toBe(true);
+  });
+
+  it('recognises certificate failures by Node error code', () => {
+    expect(isSSLCertificateError({ code: 'CERT_HAS_EXPIRED' })).toBe(true);
+    expect(isSSLCertificateError({ code: 'ERR_TLS_CERT_ALTNAME_INVALID' })).toBe(true);
+  });
+
+  it('reads the message off a plain thrown object', () => {
+    // Regression: String({...}) is "[object Object]", so every substring check
+    // missed and undici-style rejections were miscategorised as generic
+    // connection failures.
+    expect(isSSLCertificateError({ message: 'certificate has expired' })).toBe(true);
+  });
+
+  it('falls back to the serialised object when there is no message', () => {
+    expect(isSSLCertificateError({ reason: 'bad certificate' })).toBe(true);
+  });
+
+  it('rejects unrelated and empty errors', () => {
+    expect(isSSLCertificateError(new Error('connect ECONNREFUSED'))).toBe(false);
+    expect(isSSLCertificateError({ code: 'ENOTFOUND' })).toBe(false);
+    expect(isSSLCertificateError(null)).toBe(false);
+    expect(isSSLCertificateError(undefined)).toBe(false);
+    expect(isSSLCertificateError('')).toBe(false);
+  });
+});

--- a/tests/unit/utils/html-css-parser.test.ts
+++ b/tests/unit/utils/html-css-parser.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from 'node-html-parser';
+
+import {
+  filterStorybookCSS,
+  filterStorybookStyles,
+  extractClasses,
+  extractStyles,
+  extractCustomProperties,
+  parseCSSRules,
+  parseHTMLBasic,
+  parseHTMLDetailed,
+  extractDesignTokens,
+} from '../../../src/utils/html-css-parser.js';
+
+describe('filterStorybookCSS', () => {
+  it('drops Storybook chrome and keeps design-system rules', () => {
+    const css = `
+      .sb-show-main { padding: 0; }
+      .btn { color: red; }
+      #storybook-root { height: 100%; }
+      .card { border: 1px solid #ccc; }
+    `;
+
+    const filtered = filterStorybookCSS(css);
+
+    expect(filtered).toContain('.btn');
+    expect(filtered).toContain('.card');
+    expect(filtered).not.toContain('sb-show-main');
+    expect(filtered).not.toContain('storybook-root');
+  });
+
+  it('drops emotion hash classes and docs wrappers', () => {
+    const filtered = filterStorybookCSS(
+      '.css-1x2y3z { color: blue; } .sbdocs-title { margin: 0; } .badge { color: green; }'
+    );
+
+    expect(filtered).toBe('.badge { color: green; }');
+  });
+
+  it('keeps a whole at-rule block together', () => {
+    const filtered = filterStorybookCSS('@media (min-width: 40em) { .grid { display: grid; } }');
+
+    expect(filtered).toBe('@media (min-width: 40em) { .grid { display: grid; } }');
+  });
+
+  it('returns an empty string for non-CSS input', () => {
+    expect(filterStorybookCSS('')).toBe('');
+    expect(filterStorybookCSS(null as any)).toBe('');
+    expect(filterStorybookCSS(undefined as any)).toBe('');
+    expect(filterStorybookCSS(42 as any)).toBe('');
+  });
+
+  it('ignores a rule that never closes', () => {
+    expect(filterStorybookCSS('.btn { color: red;')).toBe('');
+  });
+});
+
+describe('filterStorybookStyles', () => {
+  it('filters each sheet and drops the ones left empty', () => {
+    const result = filterStorybookStyles([
+      '.sb-show-main { padding: 0; }',
+      '.btn { color: red; }',
+      '',
+    ]);
+
+    expect(result).toEqual(['.btn { color: red; }']);
+  });
+});
+
+describe('extractClasses', () => {
+  it('collects unique classes across quote styles', () => {
+    const classes = extractClasses(
+      `<div class="card card--large"><span class='badge'>1</span><b class="card">x</b></div>`
+    );
+
+    expect(classes.sort()).toEqual(['badge', 'card', 'card--large']);
+  });
+
+  it('tolerates extra whitespace in the attribute', () => {
+    expect(extractClasses('<div class="  a   b  ">x</div>').sort()).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty list when there are no classes', () => {
+    expect(extractClasses('<div>plain</div>')).toEqual([]);
+  });
+});
+
+describe('extractStyles', () => {
+  it('picks up inline style tags and notes external stylesheets', () => {
+    const root = parse(
+      `<html><head>
+         <style>.btn { color: red; }</style>
+         <link rel="stylesheet" href="/main.css">
+         <link rel="icon" href="/favicon.ico">
+       </head><body></body></html>`
+    );
+
+    expect(extractStyles(root)).toEqual([
+      '.btn { color: red; }',
+      '/* External stylesheet: /main.css */',
+    ]);
+  });
+});
+
+describe('extractCustomProperties', () => {
+  it('collects custom properties into the target object', () => {
+    expect(extractCustomProperties(':root { --brand: #ff0000; --gap: 8px; }')).toEqual({
+      '--brand': '#ff0000',
+      '--gap': '8px',
+    });
+  });
+
+  it('merges into a caller-supplied accumulator, last write winning', () => {
+    const target = { '--brand': '#000000' };
+    extractCustomProperties('--brand: #ffffff; --radius: 4px', target);
+
+    expect(target).toEqual({ '--brand': '#ffffff', '--radius': '4px' });
+  });
+
+  it('ignores regular declarations', () => {
+    expect(extractCustomProperties('color: red; padding: 4px')).toEqual({});
+  });
+});
+
+describe('parseCSSRules', () => {
+  it('reads every declaration in a rule, not just the first', () => {
+    // Regression: the old single-regex scan folded the `;` separator into the
+    // next property name, so this rule came back as
+    // { color: 'red', '; padding': '4px' }.
+    const rules = parseCSSRules('.btn { color: red; padding: 4px 8px; border: none; }');
+
+    expect(rules).toEqual([
+      {
+        selector: '.btn',
+        styles: { color: 'red', padding: '4px 8px', border: 'none' },
+      },
+    ]);
+  });
+
+  it('handles a value containing a colon', () => {
+    const rules = parseCSSRules('.hero { background: url(http://example.com/a.png); }');
+
+    expect(rules[0]!.styles['background']).toBe('url(http://example.com/a.png)');
+  });
+
+  it('parses multiple rules and skips empty ones', () => {
+    const rules = parseCSSRules('.a { color: red } .empty { } .b { color: blue }');
+
+    expect(rules.map(r => r.selector)).toEqual(['.a', '.b']);
+  });
+
+  it('returns nothing for input with no rules', () => {
+    expect(parseCSSRules('')).toEqual([]);
+  });
+});
+
+describe('parseHTMLBasic', () => {
+  it('returns styles, classes and custom properties together', () => {
+    const result = parseHTMLBasic(
+      `<html><head><style>:root { --brand: #f00; }</style></head>
+       <body><div class="card">hi</div></body></html>`
+    );
+
+    expect(result.styles).toEqual([':root { --brand: #f00; }']);
+    expect(result.classes).toEqual(['card']);
+    expect(result.customProperties).toEqual({ '--brand': '#f00' });
+  });
+});
+
+describe('parseHTMLDetailed', () => {
+  it('collects inline styles keyed by id, falling back to the tag name', () => {
+    const result = parseHTMLDetailed(
+      `<div id="hero" style="--pad: 2px; color: red"><span style="margin: 0">x</span></div>`
+    );
+
+    expect(result.inlineStyles).toEqual({
+      hero: '--pad: 2px; color: red',
+      span: 'margin: 0',
+    });
+    expect(result.customProperties).toEqual({ '--pad': '2px' });
+  });
+
+  it('returns sorted, de-duplicated class names', () => {
+    const result = parseHTMLDetailed('<div class="z a"><span class="a m">x</span></div>');
+
+    expect(result.classNames).toEqual(['a', 'm', 'z']);
+  });
+
+  it('parses the supplied stylesheets into rules', () => {
+    const result = parseHTMLDetailed('<div class="btn">x</div>', [
+      '.btn { color: red; } :root { --brand: #00f; }',
+    ]);
+
+    expect(result.cssRules.map(r => r.selector)).toEqual(['.btn', ':root']);
+    expect(result.customProperties).toEqual({ '--brand': '#00f' });
+  });
+});
+
+describe('extractDesignTokens', () => {
+  it('categorises tokens by name and value', () => {
+    const tokens = extractDesignTokens(`:root {
+      --color-primary: #0055ff;
+      --spacing-md: 16px;
+      --font-family-base: Inter, sans-serif;
+      --shadow-lg: 0 4px 8px rgba(0,0,0,.2);
+      --border-style: solid;
+      --transition-speed: ease-in-out;
+    }`);
+
+    const byName = Object.fromEntries(tokens.map(t => [t.name, t.type]));
+
+    expect(byName['--color-primary']).toBe('color');
+    expect(byName['--spacing-md']).toBe('spacing');
+    expect(byName['--font-family-base']).toBe('typography');
+    expect(byName['--shadow-lg']).toBe('shadow');
+    expect(byName['--border-style']).toBe('border');
+    expect(byName['--transition-speed']).toBe('other');
+  });
+
+  it('lets a bare unit value win over the border name', () => {
+    // Documented quirk, not an accident of this test: spacing is checked
+    // before border, and `4px` matches the spacing value pattern, so
+    // `--border-radius: 4px` is typed as spacing while `--border-radius: 50%`
+    // — same token, different unit — is too. Only non-unit values reach the
+    // border branch.
+    expect(extractDesignTokens('--border-radius: 4px;')[0]!.type).toBe('spacing');
+    expect(extractDesignTokens('--border-radius: 0.25em 0;')[0]!.type).toBe('border');
+  });
+
+  it('detects a colour from the value when the name gives nothing away', () => {
+    const tokens = extractDesignTokens('--brand: #fff; --accent: rgb(0, 0, 0);');
+
+    expect(tokens.map(t => t.type)).toEqual(['color', 'color']);
+  });
+
+  it('keeps the raw value', () => {
+    const [token] = extractDesignTokens('--gap: 1.5rem;');
+
+    expect(token).toEqual({ name: '--gap', value: '1.5rem', type: 'spacing' });
+  });
+
+  it('returns nothing when there are no custom properties', () => {
+    expect(extractDesignTokens('.btn { color: red; }')).toEqual([]);
+  });
+});

--- a/tests/unit/utils/pagination.test.ts
+++ b/tests/unit/utils/pagination.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+import { applyPagination, formatPaginationMessage } from '../../../src/utils/pagination.js';
+
+const items = (n: number) => Array.from({ length: n }, (_, i) => `item-${i + 1}`);
+
+describe('applyPagination', () => {
+  it('defaults to page 1 with 20 items per page', () => {
+    const result = applyPagination(items(50), {});
+
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+    expect(result.items).toHaveLength(20);
+    expect(result.items[0]).toBe('item-1');
+    expect(result.items[19]).toBe('item-20');
+    expect(result.totalItems).toBe(50);
+    expect(result.totalPages).toBe(3);
+  });
+
+  it('slices the requested page', () => {
+    const result = applyPagination(items(50), { page: 2, pageSize: 10 });
+
+    expect(result.items).toEqual(items(50).slice(10, 20));
+    expect(result.startIndex).toBe(10);
+    expect(result.endIndex).toBe(20);
+  });
+
+  it('returns a short last page rather than padding it', () => {
+    const result = applyPagination(items(25), { page: 3, pageSize: 10 });
+
+    expect(result.items).toEqual(['item-21', 'item-22', 'item-23', 'item-24', 'item-25']);
+    expect(result.endIndex).toBe(25);
+    expect(result.totalPages).toBe(3);
+  });
+
+  it('rejects a page past the end and names the valid range', () => {
+    expect(() => applyPagination(items(25), { page: 4, pageSize: 10 })).toThrowError(
+      'Page 4 exceeds total pages (3). Please use a page number between 1 and 3.'
+    );
+  });
+
+  it('allows page 1 of an empty list instead of throwing', () => {
+    // totalPages is 0 here, so the bounds check would reject every page. An
+    // empty result set is a normal answer — a Storybook with no matches for a
+    // filter — not a caller error.
+    const result = applyPagination([], { page: 1 });
+
+    expect(result.items).toEqual([]);
+    expect(result.totalItems).toBe(0);
+    expect(result.totalPages).toBe(0);
+  });
+
+  it('handles a page size larger than the collection', () => {
+    const result = applyPagination(items(3), { pageSize: 100 });
+
+    expect(result.items).toHaveLength(3);
+    expect(result.totalPages).toBe(1);
+    expect(result.endIndex).toBe(3);
+  });
+});
+
+describe('formatPaginationMessage', () => {
+  it('summarises a page without a suffix', () => {
+    const result = applyPagination(items(50), { page: 2, pageSize: 20 });
+
+    expect(formatPaginationMessage(result, 'Found')).toBe(
+      'Found 50 items (showing page 2/3 20 items)'
+    );
+  });
+
+  it('appends the caller suffix', () => {
+    const result = applyPagination(items(5), {});
+
+    expect(formatPaginationMessage(result, 'Found', 'filter: none')).toBe(
+      'Found 5 items, (showing page 1/1, 5 items, filter: none)'
+    );
+  });
+});

--- a/tests/unit/utils/story-mapper.test.ts
+++ b/tests/unit/utils/story-mapper.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  mapStoriesToComponents,
+  getComponentsArray,
+  toCompactComponent,
+  toCompactComponents,
+} from '../../../src/utils/story-mapper.js';
+
+const story = (id: string, title: string, name: string) => ({ id, title, name });
+
+const stories = {
+  'components-button--primary': story('components-button--primary', 'Components/Button', 'Primary'),
+  'components-button--secondary': story(
+    'components-button--secondary',
+    'Components/Button',
+    'Secondary'
+  ),
+  'components-forms-input--default': story(
+    'components-forms-input--default',
+    'Components/Forms/Input',
+    'Default'
+  ),
+  'alert--default': story('alert--default', 'Alert', 'Default'),
+};
+
+describe('mapStoriesToComponents', () => {
+  it('groups stories by component and derives id, name and category', () => {
+    const map = mapStoriesToComponents(stories);
+
+    expect([...map.keys()].sort()).toEqual(['Alert', 'Button', 'Input']);
+
+    const button = map.get('Button')!;
+    expect(button.id).toBe('components-button');
+    expect(button.title).toBe('Components/Button');
+    expect(button.category).toBe('Components');
+    expect(button.stories).toHaveLength(2);
+
+    const input = map.get('Input')!;
+    expect(input.category).toBe('Components/Forms');
+  });
+
+  it('leaves category unset for a top-level story', () => {
+    const alert = mapStoriesToComponents(stories).get('Alert')!;
+
+    expect(alert.name).toBe('Alert');
+    expect(alert.category).toBeUndefined();
+  });
+
+  it('accepts an array as well as a keyed object', () => {
+    const fromArray = mapStoriesToComponents(Object.values(stories));
+    const fromObject = mapStoriesToComponents(stories);
+
+    expect([...fromArray.keys()]).toEqual([...fromObject.keys()]);
+  });
+
+  it('applies the filter before grouping', () => {
+    const map = mapStoriesToComponents(stories, {
+      filterFn: (_story, _name, category) => category === 'Components',
+    });
+
+    expect([...map.keys()]).toEqual(['Button']);
+  });
+
+  it('passes the derived name and category to the filter', () => {
+    const seen: Array<[string, string | undefined]> = [];
+    mapStoriesToComponents(stories, {
+      filterFn: (_story, name, category) => {
+        seen.push([name, category]);
+        return false;
+      },
+    });
+
+    expect(seen).toContainEqual(['Input', 'Components/Forms']);
+    expect(seen).toContainEqual(['Alert', undefined]);
+  });
+
+  it('keys by lowercased title when asked, so same-named components stay apart', () => {
+    // Two different "Button" components under different paths collapse into one
+    // entry under the default name key. Keying by title keeps them separate.
+    const collision = {
+      a: story('core-button--default', 'Core/Button', 'Default'),
+      b: story('legacy-button--default', 'Legacy/Button', 'Default'),
+    };
+
+    expect(mapStoriesToComponents(collision).size).toBe(1);
+
+    const byTitle = mapStoriesToComponents(collision, { useComponentKey: 'title' });
+    expect(byTitle.size).toBe(2);
+    expect([...byTitle.keys()].sort()).toEqual(['core/button', 'legacy/button']);
+  });
+
+  it('falls back to the whole id when there is no variant suffix', () => {
+    const map = mapStoriesToComponents([story('standalone', 'Standalone', 'Default')]);
+
+    expect(map.get('Standalone')!.id).toBe('standalone');
+  });
+});
+
+describe('getComponentsArray', () => {
+  it('sorts components by name', () => {
+    const names = getComponentsArray(mapStoriesToComponents(stories)).map(c => c.name);
+
+    expect(names).toEqual(['Alert', 'Button', 'Input']);
+  });
+});
+
+describe('toCompactComponent', () => {
+  it('replaces the story list with a count', () => {
+    const button = mapStoriesToComponents(stories).get('Button')!;
+
+    expect(toCompactComponent(button)).toEqual({
+      id: 'components-button',
+      name: 'Button',
+      title: 'Components/Button',
+      category: 'Components',
+      variantCount: 2,
+    });
+  });
+
+  it('omits category when the component has none', () => {
+    const alert = mapStoriesToComponents(stories).get('Alert')!;
+
+    expect(toCompactComponent(alert)).not.toHaveProperty('category');
+  });
+
+  it('reports zero variants when stories are missing', () => {
+    const compact = toCompactComponent({ id: 'x', name: 'X', title: 'X' } as any);
+
+    expect(compact.variantCount).toBe(0);
+  });
+
+  it('maps a whole array', () => {
+    const components = getComponentsArray(mapStoriesToComponents(stories));
+
+    expect(toCompactComponents(components).map(c => c.variantCount)).toEqual([1, 2, 1]);
+  });
+});

--- a/tests/unit/utils/storybook-client.test.ts
+++ b/tests/unit/utils/storybook-client.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { STORY_ENTRIES } from '../../helpers/storybook-fixture.js';
+
+const puppeteerInstances: Array<{
+  launch: ReturnType<typeof vi.fn>;
+  fetchComponentHTML: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}> = [];
+
+let launchBehaviour: () => Promise<void> = async () => {};
+
+vi.mock('../../../src/utils/puppeteer-client.js', () => ({
+  PuppeteerClient: vi.fn(function () {
+    const instance = {
+      launch: vi.fn(() => launchBehaviour()),
+      fetchComponentHTML: vi.fn(async (_url: string, storyId: string) => ({
+        storyId,
+        html: '<button class="btn">Rendered</button>',
+        styles: [],
+        classes: ['btn'],
+      })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    puppeteerInstances.push(instance);
+    return instance;
+  }),
+}));
+
+const { StorybookClient } = await import('../../../src/utils/storybook-client.js');
+
+const INDEX = { v: 5, entries: STORY_ENTRIES };
+
+const iframeHTML = (inner: string) =>
+  `<html><head><style>.btn { color: red; }</style></head>
+   <body><div id="storybook-root">${inner}</div></body></html>`;
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => body,
+});
+
+const htmlResponse = (body: string) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  text: async () => body,
+});
+
+const failedResponse = (status: number, statusText: string) => ({
+  ok: false,
+  status,
+  statusText,
+});
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  puppeteerInstances.length = 0;
+  launchBehaviour = async () => {};
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  delete process.env.STORYBOOK_URL;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.STORYBOOK_URL;
+});
+
+describe('StorybookClient construction', () => {
+  it('defaults to localhost:6006', () => {
+    expect(new StorybookClient().getStorybookUrl()).toBe('http://localhost:6006');
+  });
+
+  it('reads STORYBOOK_URL from the environment', () => {
+    process.env.STORYBOOK_URL = 'https://storybook.example.com';
+
+    expect(new StorybookClient().getStorybookUrl()).toBe('https://storybook.example.com');
+  });
+
+  it('prefers an explicit base URL over the environment', () => {
+    process.env.STORYBOOK_URL = 'https://env.example.com';
+
+    expect(new StorybookClient('https://arg.example.com').getStorybookUrl()).toBe(
+      'https://arg.example.com'
+    );
+  });
+
+  it('strips a trailing slash so URLs do not double up', () => {
+    expect(new StorybookClient('http://localhost:6006/').getStorybookUrl()).toBe(
+      'http://localhost:6006'
+    );
+  });
+
+  it('rejects a value that is not a URL', () => {
+    expect(() => new StorybookClient('not a url')).toThrowError(
+      'STORYBOOK_URL must be a valid URL starting with http:// or https://'
+    );
+  });
+
+  it('rejects a bare host:port, which parses as a URL but has no scheme', () => {
+    // `new URL('localhost:6006')` succeeds — "localhost:" reads as the scheme —
+    // so this is caught by the http check rather than the parse.
+    expect(() => new StorybookClient('localhost:6006')).toThrowError(
+      'STORYBOOK_URL must start with http:// or https://'
+    );
+  });
+
+  it('rejects a non-HTTP scheme', () => {
+    expect(() => new StorybookClient('ftp://localhost:6006')).toThrowError(
+      'STORYBOOK_URL must start with http:// or https://'
+    );
+  });
+});
+
+describe('fetchStoriesIndex', () => {
+  it('reads index.json', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(INDEX));
+
+    const index = await new StorybookClient().fetchStoriesIndex();
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://localhost:6006/index.json');
+    expect(index).toEqual(INDEX);
+  });
+
+  it('falls back to stories.json for older Storybooks', async () => {
+    fetchMock
+      .mockResolvedValueOnce(failedResponse(404, 'Not Found'))
+      .mockResolvedValueOnce(jsonResponse(INDEX));
+
+    await new StorybookClient().fetchStoriesIndex();
+
+    expect(fetchMock.mock.calls[1]![0]).toBe('http://localhost:6006/stories.json');
+  });
+
+  it('caches the index instead of refetching', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(INDEX));
+    const client = new StorybookClient();
+
+    await client.fetchStoriesIndex();
+    await client.fetchStoriesIndex();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports both URLs failing with troubleshooting steps', async () => {
+    fetchMock.mockResolvedValue(failedResponse(500, 'Internal Server Error'));
+
+    await expect(new StorybookClient().fetchStoriesIndex()).rejects.toThrow(
+      /Failed to fetch Storybook index from http:\/\/localhost:6006\..*HTTP 500/s
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('names a timeout as such', async () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    fetchMock.mockRejectedValue(abort);
+
+    await expect(new StorybookClient().fetchStoriesIndex()).rejects.toThrow(
+      /Request timeout while fetching/
+    );
+  });
+});
+
+describe('fetchComponentHTML', () => {
+  const clientWithIndex = () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(INDEX));
+    return new StorybookClient();
+  };
+
+  it('rejects a story id that is not in the index', async () => {
+    const client = clientWithIndex();
+
+    await expect(client.fetchComponentHTML('ghost--default')).rejects.toThrow(
+      /\[NOT_FOUND_ERROR\]/
+    );
+  });
+
+  it('uses statically rendered markup without starting a browser', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockResolvedValueOnce(
+      htmlResponse(iframeHTML('<button class="btn btn--primary">Click me</button>'))
+    );
+
+    const result = await client.fetchComponentHTML('components-button--primary');
+
+    expect(result.html).toBe('<button class="btn btn--primary">Click me</button>');
+    expect(result.classes).toEqual(['btn', 'btn--primary']);
+    expect(result.styles).toEqual(['.btn { color: red; }']);
+    expect(puppeteerInstances).toHaveLength(0);
+  });
+
+  it('encodes the story id in the iframe URL', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockResolvedValueOnce(htmlResponse(iframeHTML('<b>x</b>')));
+
+    await client.fetchComponentHTML('components-forms-input--default');
+
+    expect(fetchMock.mock.calls[1]![0]).toBe(
+      'http://localhost:6006/iframe.html?id=components-forms-input--default'
+    );
+  });
+
+  it('falls back to the browser when the story renders client-side', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockResolvedValueOnce(
+      htmlResponse(iframeHTML('<div class="sb-nopreview">No Preview</div>'))
+    );
+
+    const result = await client.fetchComponentHTML('components-button--primary');
+
+    expect(result.html).toBe('<button class="btn">Rendered</button>');
+    expect(puppeteerInstances).toHaveLength(1);
+    expect(puppeteerInstances[0]!.fetchComponentHTML).toHaveBeenCalledWith(
+      'http://localhost:6006/iframe.html?id=components-button--primary',
+      'components-button--primary'
+    );
+  });
+
+  it('falls back to the browser when the root is empty', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockResolvedValueOnce(htmlResponse(iframeHTML('   ')));
+
+    await client.fetchComponentHTML('components-button--primary');
+
+    expect(puppeteerInstances).toHaveLength(1);
+  });
+
+  it('launches the browser once for concurrent requests', async () => {
+    const client = clientWithIndex();
+    await client.fetchStoriesIndex();
+    fetchMock.mockResolvedValue(htmlResponse(iframeHTML('<div class="sb-nopreview"></div>')));
+
+    await Promise.all([
+      client.fetchComponentHTML('components-button--primary'),
+      client.fetchComponentHTML('components-button--default'),
+      client.fetchComponentHTML('alert--danger'),
+    ]);
+
+    expect(puppeteerInstances).toHaveLength(1);
+  });
+
+  it('retries the launch after a failure instead of caching it', async () => {
+    const client = clientWithIndex();
+    await client.fetchStoriesIndex();
+    fetchMock.mockResolvedValue(htmlResponse(iframeHTML('<div class="sb-nopreview"></div>')));
+    launchBehaviour = async () => {
+      throw new Error('Failed to launch the browser process');
+    };
+
+    await expect(client.fetchComponentHTML('components-button--primary')).rejects.toThrow(
+      /CONNECTION_ERROR/
+    );
+
+    launchBehaviour = async () => {};
+    await expect(client.fetchComponentHTML('alert--danger')).resolves.toMatchObject({
+      storyId: 'alert--danger',
+    });
+    expect(puppeteerInstances).toHaveLength(2);
+  });
+
+  it('caches a story it has already extracted', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockResolvedValueOnce(htmlResponse(iframeHTML('<b>x</b>')));
+
+    await client.fetchComponentHTML('components-button--primary');
+    await client.fetchComponentHTML('components-button--primary');
+
+    // One index fetch plus one iframe fetch; the second call was served from cache.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports an iframe that will not load, with its status', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockResolvedValueOnce(failedResponse(502, 'Bad Gateway'));
+
+    await expect(client.fetchComponentHTML('components-button--primary')).rejects.toThrow(
+      /\[CONNECTION_ERROR\].*Status: 502/s
+    );
+  });
+
+  it('reports a timeout against the story it was fetching', async () => {
+    const client = clientWithIndex();
+    fetchMock.mockRejectedValueOnce(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+
+    await expect(client.fetchComponentHTML('components-button--primary')).rejects.toThrow(
+      /\[TIMEOUT_ERROR\].*for story components-button--primary/s
+    );
+  });
+});
+
+describe('close', () => {
+  it('shuts the browser down and lets the next call start a new one', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(INDEX));
+    const client = new StorybookClient();
+    fetchMock.mockResolvedValue(htmlResponse(iframeHTML('<div class="sb-nopreview"></div>')));
+
+    await client.fetchComponentHTML('components-button--primary');
+    await client.close();
+
+    expect(puppeteerInstances[0]!.close).toHaveBeenCalled();
+
+    await client.fetchComponentHTML('alert--danger');
+    expect(puppeteerInstances).toHaveLength(2);
+  });
+
+  it('is a no-op when no browser was ever started', async () => {
+    await expect(new StorybookClient().close()).resolves.toBeUndefined();
+    expect(puppeteerInstances).toHaveLength(0);
+  });
+
+  it('swallows a failed launch rather than throwing on shutdown', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(INDEX));
+    const client = new StorybookClient();
+    fetchMock.mockResolvedValue(htmlResponse(iframeHTML('<div class="sb-nopreview"></div>')));
+    launchBehaviour = async () => {
+      throw new Error('no browser');
+    };
+
+    await expect(client.fetchComponentHTML('components-button--primary')).rejects.toThrow();
+    await expect(client.close()).resolves.toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,15 +23,15 @@ export default defineConfig({
         'tests/**',
         'scripts/**',
       ],
-      // Today's real numbers, not an aspiration. 80 was configured but never
-      // enforced (CI ran `vitest run`, so it never loaded), and the honest
-      // figure with every source file measured is ~5%. These are a floor that
-      // stops further slippage; the follow-up test work raises them.
+      // Today's real numbers, not an aspiration — a ratchet that stops
+      // slippage. What is left uncovered is `src/index.ts` (the stdio wiring)
+      // and `puppeteer-client.ts`, which needs a real browser; both belong in
+      // an integration suite rather than here.
       thresholds: {
-        branches: 4,
-        functions: 5,
-        lines: 5,
-        statements: 5,
+        branches: 84,
+        functions: 78,
+        lines: 88,
+        statements: 87,
       },
     },
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
Coverage was ~5% with 0 of 9 tools tested. This takes it to **87% statements / 85% branches** with 225 tests, and raises the `vitest.config.ts` thresholds to match so it ratchets rather than drifts.

### What is covered

| Area | Tests |
|---|---|
| `list_components`, `search_components`, `get_component_html` | filtering, pagination, compact/full output, v3 `stories` vs v5 `entries`, variant listing, async job vs sync |
| `get_component_dependencies`, `get_theme_info`, `get_external_css` | component detection heuristics, token bucketing, same-origin check, truncation |
| `job_status`, `job_list`, `job_cancel` | lifecycle, filters, unknown ids |
| `JobQueue` | queueing, failure capture, mid-flight cancellation, sync timeout, stats |
| `StorybookClient` | URL validation, `index.json` → `stories.json` fallback, caching, static-vs-browser decision, single browser launch under concurrency, retry after a failed launch |
| parsing/pagination/cache/error helpers | full behaviour incl. edge cases |

### Three defects the tests found, fixed here

**`parseCSSRules` mis-keyed every declaration after the first.** A single `([^:]+):\s*([^;]+)` scan across the rule body swallowed the separator, so `color: red; padding: 4px` parsed as `{ color: 'red', '; padding': '4px' }`. Now split on `;` first.

**`formatError` threw away the actual cause outside development.** The category templates are generic, so on their own they can be flatly wrong — a pagination failure (`Page 9 exceeds total pages (3)`) was reported as *"Unable to connect to Storybook"*. The caller here is usually a model, which then goes and debugs the wrong system. The real message is now always appended on a `Details:` line.

**`get_theme_info` filed unit-valued tokens as spacing regardless of name.** `isSpacingValue(value)` was evaluated inside the spacing branch, ahead of the breakpoint, shadow and radius checks, so `--breakpoint-md: 960px` and `--radius-sm: 2px` both landed in `spacing`. Worse, the "no breakpoints found" fallback then populated the response with hardcoded defaults while the design system's real breakpoints sat in the wrong bucket. Name-based rules now run first; value heuristics are the fallback.

### Still uncovered

`src/index.ts` (stdio wiring) and `puppeteer-client.ts` (needs a real browser) — both belong in an integration suite rather than here.

One thing left alone deliberately: `get_theme_info` still substitutes hardcoded breakpoints when a design system defines none. With the ordering fix real breakpoints are now found, but a caller still cannot tell the invented ones from real values. Worth a separate decision.