### PR TITLE
feat: declare outputSchema on every tool

### DIFF
--- a/src/config/output-schemas.ts
+++ b/src/config/output-schemas.ts
@@ -1,0 +1,217 @@
+/**
+ * `outputSchema` declarations for every tool.
+ *
+ * A tool that declares one must return `structuredContent` matching it, which
+ * lets a client consume the result as data instead of re-parsing the JSON we
+ * happen to have embedded in the text block. The text block is unchanged, so
+ * clients that never look at `structuredContent` see exactly what they saw
+ * before.
+ *
+ * Schemas are JSON Schema 2020-12, as the MCP specification requires.
+ */
+
+const PAGINATION = {
+  type: 'object',
+  description: 'Where the returned slice sits in the full result set.',
+  properties: {
+    page: { type: 'number' },
+    pageSize: { type: 'number' },
+    totalItems: { type: 'number' },
+    totalPages: { type: 'number' },
+  },
+  required: ['page', 'pageSize', 'totalItems', 'totalPages'],
+} as const;
+
+const COMPONENT = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', description: 'Component id, e.g. "components-button"' },
+    name: { type: 'string', description: 'Component name, e.g. "Button"' },
+    title: { type: 'string', description: 'Full Storybook path, e.g. "Components/Button"' },
+    category: { type: 'string', description: 'Path above the component name; absent at top level' },
+    variantCount: { type: 'number', description: 'Number of stories; compact responses only' },
+    stories: {
+      type: 'array',
+      description: 'The raw stories; full responses only (compact=false)',
+      items: { type: 'object' },
+    },
+  },
+  required: ['id', 'name', 'title'],
+} as const;
+
+const TOKEN_MAP = {
+  type: 'object',
+  additionalProperties: { type: 'string' },
+} as const;
+
+const THEME = {
+  type: 'object',
+  properties: {
+    colors: TOKEN_MAP,
+    spacing: TOKEN_MAP,
+    typography: TOKEN_MAP,
+    breakpoints: TOKEN_MAP,
+    shadows: TOKEN_MAP,
+    radii: TOKEN_MAP,
+    other: TOKEN_MAP,
+  },
+  required: ['colors', 'spacing', 'typography', 'breakpoints', 'shadows', 'radii'],
+} as const;
+
+const JOB_SUMMARY = {
+  type: 'object',
+  properties: {
+    job_id: { type: 'string' },
+    status: { type: 'string', enum: ['queued', 'running', 'completed', 'failed', 'cancelled'] },
+    component_id: { type: 'string' },
+    created_at: { type: 'number' },
+    started_at: { type: 'number' },
+  },
+  required: ['job_id', 'status', 'component_id', 'created_at'],
+} as const;
+
+export const OUTPUT_SCHEMAS: Record<string, object> = {
+  list_components: {
+    type: 'object',
+    properties: {
+      components: { type: 'array', items: COMPONENT },
+      pagination: PAGINATION,
+    },
+    required: ['components', 'pagination'],
+  },
+
+  search_components: {
+    type: 'object',
+    properties: {
+      components: { type: 'array', items: COMPONENT },
+      description: {
+        type: 'string',
+        description: 'What the matched purpose covers; present only for a purpose search',
+      },
+      pagination: PAGINATION,
+    },
+    required: ['components', 'pagination'],
+  },
+
+  // Three shapes behind one tool: a variant list, a queued job, or the
+  // extracted markup. Which one you get depends on variantsOnly and async.
+  get_component_html: {
+    type: 'object',
+    properties: {
+      componentId: { type: 'string', description: 'variantsOnly mode' },
+      variants: { type: 'array', items: { type: 'string' }, description: 'variantsOnly mode' },
+      job_id: { type: 'string', description: 'async mode' },
+      status: { type: 'string', description: 'async mode' },
+      component_id: { type: 'string', description: 'async mode' },
+      storyId: { type: 'string', description: 'sync mode' },
+      html: { type: 'string', description: 'sync mode' },
+      classes: { type: 'array', items: { type: 'string' }, description: 'sync mode' },
+      styles: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'sync mode with includeStyles=true; Storybook boilerplate is filtered out',
+      },
+    },
+  },
+
+  get_component_dependencies: {
+    type: 'object',
+    properties: {
+      storyId: { type: 'string' },
+      dependencies: { type: 'array', items: { type: 'string' } },
+      internalComponents: { type: 'array', items: { type: 'string' } },
+      externalComponents: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Components matching a known library prefix (Mui, Ant, Bootstrap, ...)',
+      },
+    },
+    required: ['storyId', 'dependencies', 'internalComponents', 'externalComponents'],
+  },
+
+  get_theme_info: {
+    type: 'object',
+    properties: {
+      theme: THEME,
+      totalTokens: { type: 'number' },
+      sourceStoryId: {
+        type: 'string',
+        description: 'The story the tokens were read from',
+      },
+    },
+    required: ['theme', 'totalTokens', 'sourceStoryId'],
+  },
+
+  get_external_css: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'The absolute URL that was fetched' },
+      originalUrl: { type: 'string', description: 'The URL as supplied by the caller' },
+      fileSize: { type: 'number' },
+      fileSizeFormatted: { type: 'string' },
+      analysis: {
+        type: 'object',
+        properties: {
+          totalRules: { type: 'number' },
+          customProperties: { type: 'number' },
+          mediaQueries: { type: 'number' },
+          selectors: { type: 'number' },
+          declarations: { type: 'number' },
+        },
+        required: ['totalRules', 'customProperties', 'mediaQueries', 'selectors', 'declarations'],
+      },
+      tokensExtracted: { type: 'boolean' },
+      tokenCount: { type: 'number' },
+      tokens: { ...THEME, description: 'null when extractTokens=false' },
+      content: { type: 'string', description: 'Only when includeFullCSS=true' },
+      truncated: { type: 'boolean' },
+      displayedSize: { type: 'number' },
+      truncationWarning: { type: 'string' },
+    },
+    required: ['url', 'originalUrl', 'fileSize', 'analysis', 'tokensExtracted', 'tokenCount'],
+  },
+
+  job_status: {
+    type: 'object',
+    properties: {
+      job_id: { type: 'string' },
+      status: { type: 'string', enum: ['queued', 'running', 'completed', 'failed', 'cancelled'] },
+      result: { type: 'object', description: 'Present once the job completes' },
+      error: { type: 'string', description: 'Present when the job failed' },
+      created_at: { type: 'number' },
+      started_at: { type: 'number' },
+      completed_at: { type: 'number' },
+    },
+    required: ['job_id', 'status', 'created_at'],
+  },
+
+  job_list: {
+    type: 'object',
+    properties: {
+      jobs: { type: 'array', items: JOB_SUMMARY },
+      stats: {
+        type: 'object',
+        properties: {
+          queued: { type: 'number' },
+          running: { type: 'number' },
+          completed: { type: 'number' },
+          failed: { type: 'number', description: 'Includes cancelled jobs' },
+        },
+        required: ['queued', 'running', 'completed', 'failed'],
+      },
+    },
+    required: ['jobs', 'stats'],
+  },
+
+  job_cancel: {
+    type: 'object',
+    properties: {
+      job_id: { type: 'string' },
+      cancelled: {
+        type: 'boolean',
+        description: 'False when the job was unknown or had already finished',
+      },
+    },
+    required: ['job_id', 'cancelled'],
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 
 import * as tools from './tools/index.js';
 import { jobQueue } from './services/job-queue.js';
+import { OUTPUT_SCHEMAS } from './config/output-schemas.js';
 
 const toolHandlers = new Map<string, (input: any) => Promise<any>>([
   ['list_components', tools.handleListComponents],
@@ -27,6 +28,9 @@ const toolHandlers = new Map<string, (input: any) => Promise<any>>([
   ['job_list', tools.handleJobList],
 ]);
 
+// Declared here rather than on each tool definition so the schemas stay in
+// one file next to each other; a mismatch between two of them is easier to
+// spot than a mismatch spread across nine.
 const allTools = [
   tools.listComponentsTool,
   tools.getComponentHTMLTool,
@@ -37,7 +41,7 @@ const allTools = [
   tools.jobStatusTool,
   tools.jobCancelTool,
   tools.jobListTool,
-];
+].map(tool => ({ ...tool, outputSchema: OUTPUT_SCHEMAS[tool.name] }));
 
 async function main() {
   // Start the background job processor for async operations

--- a/src/tools/list-components.ts
+++ b/src/tools/list-components.ts
@@ -68,7 +68,11 @@ export async function handleListComponents(input: any) {
     if (stories.length === 0) {
       return formatSuccessResponse(
         [],
-        `No components found in Storybook at ${client.getStorybookUrl()}. Ensure your Storybook has stories configured and is accessible. Debug info: storiesData keys: ${Object.keys(storiesData).slice(0, 5).join(', ')}`
+        `No components found in Storybook at ${client.getStorybookUrl()}. Ensure your Storybook has stories configured and is accessible. Debug info: storiesData keys: ${Object.keys(storiesData).slice(0, 5).join(', ')}`,
+        {
+          components: [],
+          pagination: { page: 1, pageSize: 0, totalItems: 0, totalPages: 0 },
+        }
       );
     }
 
@@ -99,7 +103,15 @@ export async function handleListComponents(input: any) {
         ? toCompactComponents(paginationResult.items)
         : paginationResult.items;
 
-    return formatSuccessResponse(items, message);
+    return formatSuccessResponse(items, message, {
+      components: items,
+      pagination: {
+        page: paginationResult.page,
+        pageSize: paginationResult.pageSize,
+        totalItems: paginationResult.totalItems,
+        totalPages: paginationResult.totalPages,
+      },
+    });
   } catch (error) {
     return handleErrorWithContext(error, 'list components', {
       resource: 'components list',

--- a/src/tools/search-components.ts
+++ b/src/tools/search-components.ts
@@ -282,7 +282,16 @@ export async function handleSearchComponents(input: any) {
       ? { description: purposeConfig.description, components: paginationResult.items }
       : paginationResult.items;
 
-    return formatSuccessResponse(response, message);
+    return formatSuccessResponse(response, message, {
+      components: paginationResult.items,
+      ...(purposeConfig && { description: purposeConfig.description }),
+      pagination: {
+        page: paginationResult.page,
+        pageSize: paginationResult.pageSize,
+        totalItems: paginationResult.totalItems,
+        totalPages: paginationResult.totalPages,
+      },
+    });
   } catch (error) {
     return handleErrorWithContext(error, 'search components', {
       resource: 'component search results',

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -4,6 +4,10 @@ export interface ToolResponse {
     text?: string;
     resource?: any;
   }>;
+  /** Matches the tool's declared `outputSchema`. Absent on errors. */
+  structuredContent?: Record<string, unknown>;
+  /** Set on a failed call so clients do not read the error text as a result. */
+  isError?: boolean;
 }
 
 export interface ListComponentsInput {

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -18,6 +18,7 @@ export function handleError(error: unknown): ToolResponse {
         text: `Error: ${message}`,
       },
     ],
+    isError: true,
   };
 }
 
@@ -32,6 +33,10 @@ export function handleFormattedError(formattedError: FormattedError): ToolRespon
         text: `Error: ${formattedError.message}`,
       },
     ],
+    // Without this a client reads the error text as a successful result, and
+    // a tool that declares an outputSchema would additionally look like it
+    // returned nothing structured for no reason.
+    isError: true,
   };
 }
 
@@ -91,8 +96,17 @@ export function handleErrorWithContext(
   return handleCategorizedError(category, fullContext, errorToPass);
 }
 
-export function formatSuccessResponse(data: any, message?: string): ToolResponse {
-  return {
+/**
+ * @param structured what to expose as `structuredContent`, when it differs
+ *   from `data` — needed where `data` is an array, since `structuredContent`
+ *   must be an object. Omit it and `data` is used as-is.
+ */
+export function formatSuccessResponse(
+  data: any,
+  message?: string,
+  structured?: Record<string, unknown>
+): ToolResponse {
+  const response: ToolResponse = {
     content: [
       {
         type: 'text',
@@ -102,6 +116,16 @@ export function formatSuccessResponse(data: any, message?: string): ToolResponse
       },
     ],
   };
+
+  // Every tool declares an outputSchema, so every success has to carry the
+  // matching structured payload. The text block above is left exactly as it
+  // was: clients that only read text are unaffected.
+  const payload = structured ?? (Array.isArray(data) ? undefined : data);
+  if (payload && typeof payload === 'object') {
+    response.structuredContent = payload as Record<string, unknown>;
+  }
+
+  return response;
 }
 
 export function formatTextResponse(text: string): ToolResponse {

--- a/tests/unit/config/output-schemas.test.ts
+++ b/tests/unit/config/output-schemas.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { OUTPUT_SCHEMAS } from '../../../src/config/output-schemas.js';
+import {
+  createStorybookClientStub,
+  delegatingClient,
+  type StorybookClientStub,
+} from '../../helpers/storybook-fixture.js';
+
+let stub: StorybookClientStub;
+
+vi.mock('../../../src/utils/storybook-client.js', () => ({
+  StorybookClient: vi.fn(function () {
+    return delegatingClient(() => stub);
+  }),
+}));
+
+const toolsModule = await import('../../../src/tools/index.js');
+
+const TOOL_DEFINITIONS = [
+  toolsModule.listComponentsTool,
+  toolsModule.getComponentHTMLTool,
+  toolsModule.searchComponentsTool,
+  toolsModule.getComponentDependenciesTool,
+  toolsModule.getThemeInfoTool,
+  toolsModule.getExternalCSSTool,
+  toolsModule.jobStatusTool,
+  toolsModule.jobCancelTool,
+  toolsModule.jobListTool,
+];
+
+/** Minimal check of the subset of JSON Schema these declarations use. */
+function violations(schema: any, value: unknown, path = '$'): string[] {
+  if (!schema || typeof schema !== 'object') {
+    return [];
+  }
+
+  const problems: string[] = [];
+  const actual = Array.isArray(value) ? 'array' : value === null ? 'null' : typeof value;
+
+  if (schema.type && schema.type !== actual) {
+    return [`${path}: expected ${schema.type}, got ${actual}`];
+  }
+
+  if (schema.enum && !schema.enum.includes(value)) {
+    problems.push(`${path}: ${JSON.stringify(value)} not in enum`);
+  }
+
+  if (schema.type === 'object' && value && typeof value === 'object') {
+    for (const key of schema.required ?? []) {
+      if (!(key in (value as object))) {
+        problems.push(`${path}.${key}: required but missing`);
+      }
+    }
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      const childSchema = schema.properties?.[key] ?? schema.additionalProperties;
+      if (childSchema) {
+        problems.push(...violations(childSchema, child, `${path}.${key}`));
+      }
+    }
+  }
+
+  if (schema.type === 'array' && Array.isArray(value) && schema.items) {
+    value.forEach((item, i) => problems.push(...violations(schema.items, item, `${path}[${i}]`)));
+  }
+
+  return problems;
+}
+
+const expectValid = (toolName: string, response: any) => {
+  expect(response.structuredContent, `${toolName} returned no structuredContent`).toBeDefined();
+  expect(violations(OUTPUT_SCHEMAS[toolName], response.structuredContent)).toEqual([]);
+};
+
+beforeEach(() => {
+  stub = createStorybookClientStub();
+});
+
+describe('OUTPUT_SCHEMAS', () => {
+  it('covers every tool the server exposes, and nothing else', () => {
+    expect(Object.keys(OUTPUT_SCHEMAS).sort()).toEqual(TOOL_DEFINITIONS.map(t => t.name).sort());
+  });
+
+  it('declares each schema as a JSON Schema object', () => {
+    for (const [name, schema] of Object.entries(OUTPUT_SCHEMAS)) {
+      expect((schema as any).type, name).toBe('object');
+    }
+  });
+});
+
+describe('structured output matches the declared schema', () => {
+  it('list_components', async () => {
+    const response = await toolsModule.handleListComponents({});
+
+    expectValid('list_components', response);
+    expect((response as any).structuredContent.components).toHaveLength(3);
+    expect((response as any).structuredContent.pagination.totalItems).toBe(3);
+  });
+
+  it('list_components with an empty Storybook', async () => {
+    stub.fetchStoriesIndex.mockResolvedValue({ v: 5, entries: {} });
+
+    expectValid('list_components', await toolsModule.handleListComponents({}));
+  });
+
+  it('search_components', async () => {
+    expectValid('search_components', await toolsModule.handleSearchComponents({ query: '*' }));
+  });
+
+  it('search_components by purpose carries the description', async () => {
+    const response: any = await toolsModule.handleSearchComponents({ purpose: 'buttons' });
+
+    expectValid('search_components', response);
+    expect(response.structuredContent.description).toBe('Interactive button components');
+  });
+
+  it('get_component_html in all three modes', async () => {
+    expectValid(
+      'get_component_html',
+      await toolsModule.handleGetComponentHTML({
+        componentId: 'components-button',
+        variantsOnly: true,
+      })
+    );
+    expectValid(
+      'get_component_html',
+      await toolsModule.handleGetComponentHTML({ componentId: 'components-button--primary' })
+    );
+    expectValid(
+      'get_component_html',
+      await toolsModule.handleGetComponentHTML({
+        componentId: 'components-button--primary',
+        async: false,
+        includeStyles: true,
+      })
+    );
+  });
+
+  it('get_component_dependencies', async () => {
+    stub.fetchComponentHTML.mockResolvedValue({
+      storyId: 'card--default',
+      html: '<Card><MuiButton /></Card>',
+      styles: [],
+      classes: [],
+    });
+
+    expectValid(
+      'get_component_dependencies',
+      await toolsModule.handleGetComponentDependencies({ componentId: 'card--default' })
+    );
+  });
+
+  it('get_theme_info', async () => {
+    stub.fetchComponentHTML.mockResolvedValue({
+      storyId: 'alert--danger',
+      html: '<div></div>',
+      styles: [':root { --color-primary: #0055ff; }'],
+      classes: [],
+    });
+
+    expectValid('get_theme_info', await toolsModule.handleGetThemeInfo({}));
+  });
+
+  it('get_external_css', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => ':root { --color-primary: #0055ff; }',
+      })
+    );
+
+    expectValid('get_external_css', await toolsModule.handleGetExternalCSS({ cssUrl: '/a.css' }));
+    vi.unstubAllGlobals();
+  });
+
+  it('job_status, job_list and job_cancel', async () => {
+    const { job_id } = JSON.parse(
+      (
+        await toolsModule.handleGetComponentHTML({ componentId: 'alert--danger' })
+      ).content[0]!.text!.split('\n\n')[1]!
+    );
+
+    expectValid('job_status', await toolsModule.handleJobStatus({ job_id }));
+    expectValid('job_list', await toolsModule.handleJobList({}));
+    expectValid('job_cancel', await toolsModule.handleJobCancel({ job_id }));
+  });
+});
+
+describe('failed calls', () => {
+  it('are flagged with isError and carry no structured payload', async () => {
+    stub.fetchStoriesIndex.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const response: any = await toolsModule.handleListComponents({});
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredContent).toBeUndefined();
+  });
+});

--- a/tests/unit/utils/error-handler.test.ts
+++ b/tests/unit/utils/error-handler.test.ts
@@ -1,87 +1,103 @@
 import { describe, it, expect } from 'vitest';
-import { 
+import {
   handleError,
   formatSuccessResponse,
-  formatTextResponse
+  formatTextResponse,
 } from '../../../src/utils/error-handler.js';
 
 describe('error-handler', () => {
   describe('handleError', () => {
     it('should handle Error objects', () => {
       const error = new Error('Test error message');
-      
+
       const result = handleError(error);
-      
+
       expect(result).toEqual({
         content: [
           {
             type: 'text',
-            text: 'Error: Test error message'
-          }
-        ]
+            text: 'Error: Test error message',
+          },
+        ],
+        isError: true,
       });
     });
 
     it('should handle string errors', () => {
       const error = 'String error message';
-      
+
       const result = handleError(error);
-      
+
       expect(result).toEqual({
         content: [
           {
             type: 'text',
-            text: 'Error: String error message'
-          }
-        ]
+            text: 'Error: String error message',
+          },
+        ],
+        isError: true,
       });
     });
 
     it('should handle unknown error types', () => {
       const error = { some: 'object' };
-      
+
       const result = handleError(error);
-      
+
       expect(result).toEqual({
         content: [
           {
             type: 'text',
-            text: 'Error: An unknown error occurred'
-          }
-        ]
+            text: 'Error: An unknown error occurred',
+          },
+        ],
+        isError: true,
       });
     });
   });
 
   describe('formatSuccessResponse', () => {
+    it('wraps an array so structuredContent stays an object', () => {
+      // structuredContent must be an object, and several tools return a bare
+      // array, so those handlers pass an explicit wrapper.
+      const items = [{ id: 'a' }];
+
+      expect(formatSuccessResponse(items).structuredContent).toBeUndefined();
+      expect(formatSuccessResponse(items, undefined, { items }).structuredContent).toEqual({
+        items,
+      });
+    });
+
     it('should format data without message', () => {
       const data = { key: 'value' };
-      
+
       const result = formatSuccessResponse(data);
-      
+
       expect(result).toEqual({
         content: [
           {
             type: 'text',
-            text: JSON.stringify(data, null, 2)
-          }
-        ]
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+        structuredContent: data,
       });
     });
 
     it('should format data with message', () => {
       const data = { key: 'value' };
       const message = 'Success message';
-      
+
       const result = formatSuccessResponse(data, message);
-      
+
       expect(result).toEqual({
         content: [
           {
             type: 'text',
-            text: `Success message\n\n${JSON.stringify(data, null, 2)}`
-          }
-        ]
+            text: `Success message\n\n${JSON.stringify(data, null, 2)}`,
+          },
+        ],
+        structuredContent: data,
       });
     });
   });
@@ -89,16 +105,16 @@ describe('error-handler', () => {
   describe('formatTextResponse', () => {
     it('should format text response', () => {
       const text = 'Simple text response';
-      
+
       const result = formatTextResponse(text);
-      
+
       expect(result).toEqual({
         content: [
           {
             type: 'text',
-            text: 'Simple text response'
-          }
-        ]
+            text: 'Simple text response',
+          },
+        ],
       });
     });
   });


### PR DESCRIPTION
All nine tools now advertise an `outputSchema` and return matching `structuredContent`, so a client can consume results as data instead of re-parsing the JSON embedded in the text block.

**This is additive.** The text block is byte-for-byte what it was — clients that only read text see no change.

Two things worth knowing:

- `structuredContent` must be an object, and `list_components` / `search_components` return a bare array. Their structured payload wraps it as `{ components, pagination }`. The array in the text block is unchanged, so no existing response shape breaks.
- Failed calls now set `isError: true`. Without it a client reads the error text as a successful result — which matters more once a tool declares an output schema and then returns nothing structured.

Schemas live in `src/config/output-schemas.ts` rather than on each tool definition: a mismatch between two of them is easier to spot side by side than spread across nine files. `tests/unit/config/output-schemas.test.ts` asserts the file covers exactly the tools the server exposes, and validates real handler output against each schema in every mode `get_component_html` can return.

`npm run check:all` passes: 238 tests, coverage 87.7%.
